### PR TITLE
Normalize structures across the project

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,5 +1,5 @@
 const path = require('path');
-const Twinkle = require('./src/twinkle.js');
+const Twinkle = require('./src/Twinkle.js');
 const client = new Twinkle();
 
 client.loadPluginDir(path.join(__dirname, 'src', 'plugins'));

--- a/src/plugins/automod/filters/Invites.js
+++ b/src/plugins/automod/filters/Invites.js
@@ -1,4 +1,4 @@
-const Filter = require('../structs/filter.js');
+const Filter = require('../structs/Filter.js');
 
 class InvitesFilter extends Filter {
     constructor(automod) {

--- a/src/plugins/automod/filters/MassMention.js
+++ b/src/plugins/automod/filters/MassMention.js
@@ -1,4 +1,4 @@
-const Filter = require('../structs/filter.js');
+const Filter = require('../structs/Filter.js');
 
 class MassMentionFilter extends Filter {
     constructor(automod) {

--- a/src/plugins/automod/filters/Zalgo.js
+++ b/src/plugins/automod/filters/Zalgo.js
@@ -1,4 +1,4 @@
-const Filter = require('../structs/filter.js');
+const Filter = require('../structs/Filter.js');
 
 class ZalgoFilter extends Filter {
     constructor(automod) {

--- a/src/plugins/automod/index.js
+++ b/src/plugins/automod/index.js
@@ -1,4 +1,4 @@
-const Plugin = require('../../structs/plugin.js');
+const Plugin = require('../../structs/Plugin.js');
 
 class AutoModPlugin extends Plugin {
     load() {

--- a/src/plugins/commander/commands/ask.js
+++ b/src/plugins/commander/commands/ask.js
@@ -1,4 +1,4 @@
-const Command = require('../structs/command.js');
+const Command = require('../structs/Command.js');
 
 class AskCommand extends Command {
     constructor(bot) {

--- a/src/plugins/commander/commands/clear.js
+++ b/src/plugins/commander/commands/clear.js
@@ -1,5 +1,5 @@
 const got = require('got');
-const ModCommand = require('../structs/modcommand.js');
+const ModCommand = require('../structs/ModCommand.js');
 
 class ClearCommand extends ModCommand {
     constructor(bot) {

--- a/src/plugins/commander/commands/code.js
+++ b/src/plugins/commander/commands/code.js
@@ -4,7 +4,7 @@ const got = require('got');
 const path = require('path');
 const process = require('process');
 const readdir = require('recursive-readdir');
-const Command = require('../structs/command.js');
+const Command = require('../structs/Command.js');
 const Cache = require('../../../structs/cache');
 
 class CodeCommand extends Command {

--- a/src/plugins/commander/commands/code.js
+++ b/src/plugins/commander/commands/code.js
@@ -5,7 +5,7 @@ const path = require('path');
 const process = require('process');
 const readdir = require('recursive-readdir');
 const Command = require('../structs/Command.js');
-const Cache = require('../../../structs/cache');
+const Cache = require('../../../structs/Cache');
 
 class CodeCommand extends Command {
     constructor(bot) {

--- a/src/plugins/commander/commands/css.js
+++ b/src/plugins/commander/commands/css.js
@@ -1,4 +1,4 @@
-const Command = require('../structs/command.js');
+const Command = require('../structs/Command.js');
 
 class CSSRoleCommand extends Command {
     constructor(bot) {

--- a/src/plugins/commander/commands/eval.js
+++ b/src/plugins/commander/commands/eval.js
@@ -1,5 +1,5 @@
 const { Collection } = require('discord.js');
-const OPCommand = require('../structs/opcommand.js');
+const OPCommand = require('../structs/OPCommand.js');
 
 class EvalCommand extends OPCommand {
     constructor(bot) {

--- a/src/plugins/commander/commands/help.js
+++ b/src/plugins/commander/commands/help.js
@@ -1,4 +1,4 @@
-const Command = require('../structs/command.js');
+const Command = require('../structs/Command.js');
 const Cache = require('../../../structs/cache.js');
 
 class HelpCommand extends Command {

--- a/src/plugins/commander/commands/help.js
+++ b/src/plugins/commander/commands/help.js
@@ -1,5 +1,5 @@
 const Command = require('../structs/Command.js');
-const Cache = require('../../../structs/cache.js');
+const Cache = require('../../../structs/Cache.js');
 
 class HelpCommand extends Command {
     constructor(bot) {

--- a/src/plugins/commander/commands/integration.js
+++ b/src/plugins/commander/commands/integration.js
@@ -1,4 +1,4 @@
-const Command = require('../structs/command.js');
+const Command = require('../structs/Command.js');
 
 class IntegrationCommand extends Command {
     constructor(bot) {

--- a/src/plugins/commander/commands/javascript.js
+++ b/src/plugins/commander/commands/javascript.js
@@ -1,4 +1,4 @@
-const Command = require('../structs/command.js');
+const Command = require('../structs/Command.js');
 
 class JavaScriptCommand extends Command {
     constructor(bot) {

--- a/src/plugins/commander/commands/lua.js
+++ b/src/plugins/commander/commands/lua.js
@@ -1,4 +1,4 @@
-const Command = require('../structs/command.js');
+const Command = require('../structs/Command.js');
 
 class LuaRoleCommand extends Command {
     constructor(bot) {

--- a/src/plugins/commander/commands/personalcss.js
+++ b/src/plugins/commander/commands/personalcss.js
@@ -1,4 +1,4 @@
-const Command = require('../structs/command.js');
+const Command = require('../structs/Command.js');
 
 class PersonalCSSCommand extends Command {
     constructor(bot) {

--- a/src/plugins/commander/commands/personaljs.js
+++ b/src/plugins/commander/commands/personaljs.js
@@ -1,4 +1,4 @@
-const Command = require('../structs/command.js');
+const Command = require('../structs/Command.js');
 
 class PersonalJSCommand extends Command {
     constructor(bot) {

--- a/src/plugins/commander/commands/portability.js
+++ b/src/plugins/commander/commands/portability.js
@@ -1,4 +1,4 @@
-const Command = require('../structs/command.js');
+const Command = require('../structs/Command.js');
 
 class PortabilityCommand extends Command {
     constructor(bot) {

--- a/src/plugins/commander/commands/quit.js
+++ b/src/plugins/commander/commands/quit.js
@@ -1,4 +1,4 @@
-const OPCommand = require('../structs/opcommand.js');
+const OPCommand = require('../structs/OPCommand.js');
 
 class QuitCommand extends OPCommand {
     constructor(bot) {

--- a/src/plugins/commander/commands/restart.js
+++ b/src/plugins/commander/commands/restart.js
@@ -1,6 +1,6 @@
 const { spawn } = require('child_process');
 const got = require('got');
-const OPCommand = require('../structs/opcommand.js');
+const OPCommand = require('../structs/OPCommand.js');
 const DatabasePlugin = require('../../db');
 
 class RestartCommand extends OPCommand {

--- a/src/plugins/commander/commands/rules.js
+++ b/src/plugins/commander/commands/rules.js
@@ -1,4 +1,4 @@
-const Command = require('../structs/command.js');
+const Command = require('../structs/Command.js');
 
 class RulesCommand extends Command {
     constructor(bot) {

--- a/src/plugins/commander/commands/scripts.js
+++ b/src/plugins/commander/commands/scripts.js
@@ -1,4 +1,4 @@
-const Command = require('../structs/command.js');
+const Command = require('../structs/Command.js');
 
 class ScriptsCommand extends Command {
     constructor(bot) {

--- a/src/plugins/commander/commands/sitejs.js
+++ b/src/plugins/commander/commands/sitejs.js
@@ -1,4 +1,4 @@
-const Command = require('../structs/command.js');
+const Command = require('../structs/Command.js');
 
 class SiteJSCommand extends Command {
     constructor(bot) {

--- a/src/plugins/commander/commands/staff.js
+++ b/src/plugins/commander/commands/staff.js
@@ -1,4 +1,4 @@
-const Command = require('../structs/command.js');
+const Command = require('../structs/Command.js');
 
 class StaffCommand extends Command {
     constructor(bot) {

--- a/src/plugins/commander/commands/test.js
+++ b/src/plugins/commander/commands/test.js
@@ -1,4 +1,4 @@
-const OPCommand = require('../structs/opcommand.js');
+const OPCommand = require('../structs/OPCommand.js');
 
 class TestCommand extends OPCommand {
     constructor(bot) {

--- a/src/plugins/commander/commands/wikitext.js
+++ b/src/plugins/commander/commands/wikitext.js
@@ -1,4 +1,4 @@
-const Command = require('../structs/command.js');
+const Command = require('../structs/Command.js');
 
 class WikitextRoleCommand extends Command {
     constructor(bot) {

--- a/src/plugins/commander/index.js
+++ b/src/plugins/commander/index.js
@@ -1,7 +1,7 @@
 const fs = require('fs');
 const path = require('path');
-const Plugin = require('../../structs/plugin.js');
-const Collection = require('../../structs/collection.js');
+const Plugin = require('../../structs/Plugin.js');
+const Collection = require('../../structs/Collection.js');
 const LoggerPlugin = require('../logger');
 const DatabasePlugin = require('../db');
 

--- a/src/plugins/commander/structs/admincommand.js
+++ b/src/plugins/commander/structs/admincommand.js
@@ -1,11 +1,11 @@
-const Command = require('./command.js');
+const Command = require('./Command.js');
 
 class AdminCommand extends Command {
     constructor(bot) {
         super(bot);
         this.priority = 2;
     }
-    
+
     filter(message) {
         return this.isAdmin(message);
     }

--- a/src/plugins/commander/structs/modcommand.js
+++ b/src/plugins/commander/structs/modcommand.js
@@ -1,11 +1,11 @@
-const Command = require('./command.js');
+const Command = require('./Command.js');
 
 class ModCommand extends Command {
     constructor(bot) {
         super(bot);
         this.priority = 1;
     }
-    
+
     filter(message) {
         return this.isModerator(message);
     }

--- a/src/plugins/commander/structs/opcommand.js
+++ b/src/plugins/commander/structs/opcommand.js
@@ -1,4 +1,4 @@
-const Command = require('./command.js');
+const Command = require('./Command.js');
 
 class OPCommand extends Command {
     constructor(bot) {

--- a/src/plugins/db/index.js
+++ b/src/plugins/db/index.js
@@ -1,6 +1,6 @@
 const Plugin = require('../../structs/Plugin.js');
-const DropboxTransport = require('./transports/dropbox.js');
-const FSTransport = require('./transports/fs.js');
+const DropboxTransport = require('./transports/DropboxTransport.js');
+const FSTransport = require('./transports/FSTransport.js');
 
 class DatabasePlugin extends Plugin {
     load() {

--- a/src/plugins/db/index.js
+++ b/src/plugins/db/index.js
@@ -1,4 +1,4 @@
-const Plugin = require('../../structs/plugin.js');
+const Plugin = require('../../structs/Plugin.js');
 const DropboxTransport = require('./transports/dropbox.js');
 const FSTransport = require('./transports/fs.js');
 

--- a/src/plugins/db/transports/DropboxTransport.js
+++ b/src/plugins/db/transports/DropboxTransport.js
@@ -1,4 +1,4 @@
-const Transport = require('./transport.js');
+const Transport = require('./Transport.js');
 const { Dropbox } = require('dropbox');
 const fetch = require('isomorphic-fetch');
 

--- a/src/plugins/db/transports/FSTransport.js
+++ b/src/plugins/db/transports/FSTransport.js
@@ -1,6 +1,6 @@
 const fs = require('fs');
 const path = require('path');
-const Transport = require('./transport.js');
+const Transport = require('./Transport.js');
 
 class FSTransport extends Transport {
     constructor(config) {

--- a/src/plugins/fandomizer/index.js
+++ b/src/plugins/fandomizer/index.js
@@ -1,5 +1,5 @@
 const got = require('got');
-const Plugin = require('../../structs/plugin.js');
+const Plugin = require('../../structs/Plugin.js');
 
 class FandomizerPlugin extends Plugin {
     load() {

--- a/src/plugins/joinleave/index.js
+++ b/src/plugins/joinleave/index.js
@@ -1,4 +1,4 @@
-const Plugin = require('../../structs/plugin.js');
+const Plugin = require('../../structs/Plugin.js');
 
 class JoinLeavePlugin extends Plugin {
     load() {
@@ -20,7 +20,7 @@ class JoinLeave {
 
         return guild.channels.sort((a, b) => a.id - b.id).first();
     }
-    
+
     onJoin(member) {
         const channel = this.getDefaultChannel(member.guild);
         channel.send(`Hello <@${member.id}> and welcome to the Fandom Developers server! You can read useful information about the server in <#246663167537709058>`);

--- a/src/plugins/linker/index.js
+++ b/src/plugins/linker/index.js
@@ -1,6 +1,6 @@
 const got = require('got');
 const { CookieJar } = require('tough-cookie');
-const Plugin = require('../../structs/plugin.js');
+const Plugin = require('../../structs/Plugin.js');
 let config;
 
 class LinkerPlugin extends Plugin {
@@ -23,7 +23,7 @@ class Linker {
 
     async onMessage(message) {
         if (
-            message.author.bot || 
+            message.author.bot ||
             message.author.id == this.bot.client.user.id ||
             !message.guild
         ) return;
@@ -49,7 +49,7 @@ const linker = {
             let matches;
             const promises = [];
             const wiki = config.WIKIS[msg.guild.id] || config.WIKIS.default;
-        
+
             if (msg.content.startsWith(config.PREFIX)) {
                 const args = msg.content.slice(config.PREFIX.length).split(/ (.+)/);
                 const command = args.shift();
@@ -212,14 +212,14 @@ const linker = {
                     args[param] = val;
                 }
             } else {
-                args[s[0]] = s[1];     
+                args[s[0]] = s[1];
             }
         }
-        
+
         if (typeof custom == 'function') {
             return custom(parts.slice(1).join(':'), args, wiki, message);
         }
-        
+
         return linker.fetchPreview(wiki, parts.join(':'), message);
     },
     getSearch: (query, wiki) => {
@@ -386,7 +386,7 @@ const linker = {
                 },
                 json: true,
                 cookieJar: linker.jar,
-                
+
             }),
             thread ? got(`https://${wiki}.wikia.com/api/v1/User/Details`, {
                 query: {
@@ -597,7 +597,7 @@ const linker = {
     },
     getFirstSearchResult: async (wiki, query) => {
         const pages = await linker.fetchSearchResults(wiki, query, 1);
-        
+
         if (!pages) return `No search results found for \`${query}\`.`;
 
         const page = pages[0],

--- a/src/plugins/logger/index.js
+++ b/src/plugins/logger/index.js
@@ -1,7 +1,7 @@
 const fs = require('fs');
 const path = require('path');
-const Plugin = require('../../structs/plugin.js');
-const Cache = require('../../structs/cache.js');
+const Plugin = require('../../structs/Plugin.js');
+const Cache = require('../../structs/Cache.js');
 
 class LoggerPlugin extends Plugin {
     load() {

--- a/src/plugins/quoter/index.js
+++ b/src/plugins/quoter/index.js
@@ -1,5 +1,5 @@
 const got = require('got');
-const Plugin = require('../../structs/plugin.js');
+const Plugin = require('../../structs/Plugin.js');
 
 class QuoterPlugin extends Plugin {
     load() {

--- a/src/plugins/restartnotify/index.js
+++ b/src/plugins/restartnotify/index.js
@@ -1,4 +1,4 @@
-const Plugin = require('../../structs/plugin.js');
+const Plugin = require('../../structs/Plugin.js');
 const DatabasePlugin = require('../db');
 
 class RestartNotifyPlugin extends Plugin {

--- a/src/structs/cache.js
+++ b/src/structs/cache.js
@@ -1,4 +1,4 @@
-const Collection = require('./collection');
+const Collection = require('./Collection.js');
 
 class Cache extends Collection {
     get(key, generator) {


### PR DESCRIPTION
Modifying js files that export classes to be named after the class itself
command.js > Command.js
fs.js > FSTransport.js
... and so on. Should be easier to keep case sensitive considering Windows has a case insensitive file system