### PR TITLE
Improving quoting plugin

### DIFF
--- a/src/plugins/quoter/index.js
+++ b/src/plugins/quoter/index.js
@@ -91,9 +91,13 @@ class Quoter {
 
         let description = quote.content;
 
-        if (!description && message.embeds.length) {
-            description = this.stringifyEmbed(message.embeds[0]);
+        if (!description && quote.embeds.length) {
+            description = this.stringifyEmbed(quote.embeds[0]);
         }
+
+        const image = quote.attachments.size
+            ? quote.attachments.first()
+            : quote.embeds[0] && quote.embeds[0].image
 
         return {
             author: {
@@ -103,6 +107,7 @@ class Quoter {
             title: 'Click to jump',
             url: `https://discordapp.com/channels/${quote.guild.id}/${quote.channel.id}/${quote.id}`,
             description,
+            image: image || undefined,
             footer: {
                 icon_url: message.author.displayAvatarURL,
                 text: `Quoted by ${message.author.username}#${message.author.discriminator}`

--- a/src/plugins/quoter/index.js
+++ b/src/plugins/quoter/index.js
@@ -89,6 +89,12 @@ class Quoter {
             }
         }
 
+        let description = quote.content;
+
+        if (!description && message.embeds.length) {
+            description = this.stringifyEmbed(message.embeds[0]);
+        }
+
         return {
             author: {
                 icon_url: quote.author.displayAvatarURL,
@@ -96,13 +102,72 @@ class Quoter {
             },
             title: 'Click to jump',
             url: `https://discordapp.com/channels/${quote.guild.id}/${quote.channel.id}/${quote.id}`,
-            description: quote.content,
+            description,
             footer: {
                 icon_url: message.author.displayAvatarURL,
                 text: `Quoted by ${message.author.username}#${message.author.discriminator}`
             },
             timestamp: quote.createdAt.toISOString()
         };
+    }
+
+    stringifyEmbed({
+        provider,
+        author,
+        title,
+        url,
+        description,
+        fields,
+        footer,
+        timestamp
+    }) {
+        const sections = new Array(4).fill(null).map(() => []);
+
+        if (provider) {
+            let str = provider.name;
+
+            sections[0].push(str);
+        }
+
+        if (author && author.name) {
+            const name = author.url
+                ? `[${author.name}](${author.url})`
+                : `${author.name}`;
+
+            sections[0].push(`${name}`);
+        }
+
+        if (title) {
+            let str = url
+                ? `[${title}](${url})`
+                : `${title}`;
+
+            sections[0].push(str);
+        }
+
+        if (description) {
+            sections[0].push(`${description}`);
+        }
+
+        if (fields.length) {
+            for (const field of fields) {
+                sections[1].push(`${field.name}:`);
+                sections[1].push(field.value.split('\n').map(line => `  ${line}`).join('\n'));
+            }
+        }
+
+        if (footer) {
+            if (timestamp) {
+                sections[3].push(`${footer.text} • ${this.formatTime(timestamp)}`);
+            } else {
+                sections[3].push(`${footer.text}`);
+            }
+        }
+
+        return sections
+            .filter(section => section.length)
+            .map(section => section.join('\n'))
+            .join('\n\n');
     }
 }
 

--- a/src/plugins/quoter/index.js
+++ b/src/plugins/quoter/index.js
@@ -77,10 +77,22 @@ class Quoter {
     }
 
     buildQuoteEmbed(message, quote) {
+        const sameChannel = message.channel.id === quote.channel.id;
+        const sameGuild = message.guild.id === quote.guild.id;
+        let name = quote.member && quote.member.nickname || quote.author.username
+
+        if (!sameChannel) {
+            if (sameGuild) {
+                name += ` @ #${quote.channel.name}`;
+            } else {
+                name += ` @ ${quote.guild.name}#${quote.channel.name}`;
+            }
+        }
+
         return {
             author: {
                 icon_url: quote.author.displayAvatarURL,
-                name: quote.member && quote.member.nickname || quote.author.username
+                name
             },
             title: 'Click to jump',
             url: `https://discordapp.com/channels/${quote.guild.id}/${quote.channel.id}/${quote.id}`,

--- a/src/plugins/quoter/index.js
+++ b/src/plugins/quoter/index.js
@@ -60,6 +60,8 @@ class Quoter {
     }
 
     async tryFetchQuote([_, guildId, channelId, messageId]) {
+        if (guildId == '@me') return null;
+
         try {
             const channel = this.bot.client.channels.get(channelId);
             if (!channel) return null;
@@ -97,7 +99,7 @@ class Quoter {
 
         const image = quote.attachments.size
             ? quote.attachments.first()
-            : quote.embeds[0] && quote.embeds[0].image
+            : quote.embeds[0] && quote.embeds[0].image;
 
         return {
             author: {


### PR DESCRIPTION
- Embed previews
- Now has images, taken from the first image attachment or the embed image
- If the quote is on another channel, it shows the channel in author.name. If it's also in another guild, shows both
- Ignores @me guilded quotes immediately, so no quoting DMs with the bot (sadly?)