### PR TITLE
!clear improvements

### DIFF
--- a/src/plugins/commander/commands/clear.js
+++ b/src/plugins/commander/commands/clear.js
@@ -133,8 +133,10 @@ class ClearCommand extends ModCommand {
                     confirmation.delete(),
                 ]);
 
-                await this.wait(5000);
-                await result.delete();
+                if (!failures) {
+                    await this.wait(5000);
+                    await result.delete();
+                }
 
                 break;
             case this.CROSS:

--- a/src/plugins/commander/commands/clear.js
+++ b/src/plugins/commander/commands/clear.js
@@ -13,12 +13,14 @@ class ClearCommand extends ModCommand {
         this.shortdesc = 'Bulk deletes messages.';
         this.desc = 'Deletes messages in bulk from the current channel.\nYou can mention a user to only delete their messages. If you do, messages older than 2 weeks will not be able to be deleted.\nYou need have the manage messages permission to use this command.';
         this.usages = [
-            '!clear <count> [@users]'
+            '!clear <count> [@users]',
+            '!clear <messageId> [@users]',
         ];
         this.examples = [
             '!clear 50',
             '!clear 50 @Doru',
-            '!clear @Kocka 50 @Doru'
+            '!clear 5368934126654455809 @Kocka',
+            '!clear @Sophie 368934126654455809 @Doru'
         ];
     }
 

--- a/src/plugins/commander/commands/clear.js
+++ b/src/plugins/commander/commands/clear.js
@@ -5,7 +5,7 @@ const ModCommand = require('../structs/ModCommand.js');
 class ClearCommand extends ModCommand {
     constructor(bot) {
         super(bot);
-        this.aliases = ['clear', 'clean', 'clr', 'purge', 'clair'];
+        this.aliases = ['clear', 'clean', 'clr', 'purge'];
         this.CHECKMARK = '✅';
         this.CROSS = '❌';
         this.DISCORD_EPOCH = 1420070400000;

--- a/src/plugins/commander/commands/clear.js
+++ b/src/plugins/commander/commands/clear.js
@@ -11,7 +11,7 @@ class ClearCommand extends ModCommand {
         this.DISCORD_EPOCH = 1420070400000;
 
         this.shortdesc = 'Bulk deletes messages.';
-        this.desc = 'Deletes messages in bulk from the current channel.\nYou can mention a user to only delete their messages. If you do, messages older than 2 weeks will not be able to be deleted.\nYou need have the manage messages permission to use this command.';
+        this.desc = 'Deletes messages in bulk from the current channel.\nYou can mention a user to only delete their messages. If you do, messages older than 2 weeks will not be able to be deleted.\nYou can also pass a message ID instead of a limit to delete messages starting from it, inclusive.\nYou need have the manage messages permission to use this command.';
         this.usages = [
             '!clear <count> [@users]',
             '!clear <messageId> [@users]',


### PR DESCRIPTION
- Support clearing after a message ID, e.g. !clear 368934126654455809
- Don't delete result message after 5 seconds if it reports errors
- Expand the help text to describe new behavior