### PR TITLE
Make !help more flexible

### DIFF
--- a/src/plugins/commander/commands/ask.js
+++ b/src/plugins/commander/commands/ask.js
@@ -5,8 +5,8 @@ class AskCommand extends Command {
         super(bot);
         this.aliases = ['ask'];
 
-        this.shortdesc = 'Please don\'t ask just to ask, just ask.';
-        this.desc = 'Links to a website where it is advised to just ask your question and wait if someone can answer it.';
+        this.shortdesc = `Please don't ask just to ask, just ask.`;
+        this.desc = `Links to a website where it is advised to just ask your question and wait if someone can answer it.`;
         this.usages = [
             '!ask'
         ];

--- a/src/plugins/commander/commands/clear.js
+++ b/src/plugins/commander/commands/clear.js
@@ -10,8 +10,12 @@ class ClearCommand extends ModCommand {
         this.CROSS = '❌';
         this.DISCORD_EPOCH = 1420070400000;
 
-        this.shortdesc = 'Bulk deletes messages.';
-        this.desc = 'Deletes messages in bulk from the current channel.\nYou can mention a user to only delete their messages. If you do, messages older than 2 weeks will not be able to be deleted.\nYou can also pass a message ID instead of a limit to delete messages starting from it, inclusive.\nYou need have the manage messages permission to use this command.';
+        this.shortdesc = `Bulk deletes messages.`;
+        this.desc = `
+                    Deletes messages in bulk from the current channel.
+                    You can mention a user to only delete their messages. If you do, messages older than 2 weeks will not be able to be deleted.
+                    You can also pass a message ID instead of a limit to delete messages starting from it, inclusive.
+                    You need have the manage messages permission to use this command.`;
         this.usages = [
             '!clear <count> [@users]',
             '!clear <messageId> [@users]',

--- a/src/plugins/commander/commands/code.js
+++ b/src/plugins/commander/commands/code.js
@@ -14,7 +14,9 @@ class CodeCommand extends Command {
         this.cache = new Cache();
 
         this.shortdesc = 'Shows statistics and a link to the bot repository.';
-        this.desc = 'Displays info about the bot.\nShows statistics like stargazers, watchers, open issues, CPU usage, RAM, and lines of code.';
+        this.desc = `
+                    Displays info about the bot.
+                    Shows statistics like stargazers, watchers, open issues, CPU usage, RAM, and lines of code.`;
         this.usages = [
             '!code'
         ];

--- a/src/plugins/commander/commands/css.js
+++ b/src/plugins/commander/commands/css.js
@@ -5,8 +5,10 @@ class CSSRoleCommand extends Command {
         super(bot);
         this.aliases = ['css'];
 
-        this.shortdesc = 'Gives you the CSS role.';
-        this.desc = 'Gives you the CSS role if you don\'t have it, or removes it if you do.\nDeletes your message afterwards.';
+        this.shortdesc = `Gives you the CSS role.`;
+        this.desc = `
+                    Gives you the CSS role if you don't have it, or removes it if you do.
+                    Deletes your message afterwards.`;
         this.usages = [
             '!css'
         ];

--- a/src/plugins/commander/commands/eval.js
+++ b/src/plugins/commander/commands/eval.js
@@ -7,8 +7,11 @@ class EvalCommand extends OPCommand {
         this.aliases = ['eval'];
         this.hidden = true;
 
-        this.shortdesc = 'Evaluates a piece of code.';
-        this.desc = 'Runs JavaScript in a non-sandboxed environment, and returns the value if it exists.\nIf you use a code block, it will get stripped out before evaluation.\nYou need to be a bot operator to use this command.';
+        this.shortdesc = `Evaluates a piece of code.`;
+        this.desc = `
+                    Runs JavaScript in a non-sandboxed environment, and returns the value if it exists.
+                    If you use a code block, it will get stripped out before evaluation.
+                    You need to be a bot operator to use this command.`;
         this.usages = [
             '!eval <code>'
         ];

--- a/src/plugins/commander/commands/help.js
+++ b/src/plugins/commander/commands/help.js
@@ -9,8 +9,8 @@ class HelpCommand extends Command {
         this.cache = new Cache();
         this.pageSize = 8;
 
-        this.shortdesc = 'Displays an interactive embed listing all commands and their descriptions.';
-        this.desc = 'You already seem to have a pretty good idea for how it works, yeah?';
+        this.shortdesc = `Displays an interactive embed listing all commands and their descriptions.`;
+        this.desc = `You already seem to have a pretty good idea for how it works, yeah?`;
         this.usages = [
             '!help [command]'
         ];
@@ -68,7 +68,7 @@ class HelpCommand extends Command {
     getField(command) {
         return {
             name: `!${command.aliases[0]}`,
-            value: command.shortdesc || command.desc || '*No description provided.*'
+            value: this.firstLine(command.shortdesc || command.desc || '*No description provided.*')
         };
     }
 
@@ -117,9 +117,17 @@ class HelpCommand extends Command {
                 url: `${this.bot.config.SOURCE.URL}/tree/master/src/plugins/commander/commands/${fileName}.js`
             },
             title: `Command description: ${command.aliases[0]}`,
-            description: command.desc || command.shortdesc || '*No description provided.*',
+            description: this.trimLines(command.desc || command.shortdesc || '*No description provided.*'),
             fields
         };
+    }
+
+    firstLine(str) {
+        return str.trim().match(/^.*/);
+    }
+
+    trimLines(str) {
+        return str.trim().replace(/^\s+/gm, '');
     }
 
     formatUsage(usage) {

--- a/src/plugins/commander/commands/integration.js
+++ b/src/plugins/commander/commands/integration.js
@@ -5,8 +5,8 @@ class IntegrationCommand extends Command {
         super(bot);
         this.aliases = ['integration', 'integrator', 'discord'];
 
-        this.shortdesc = 'Gives installation instructios for DiscordIntegrator.';
-        this.desc = 'Links to the instruction manual for DiscordIntegrator.';
+        this.shortdesc = `Gives installation instructios for DiscordIntegrator.`;
+        this.desc = `Links to the instruction manual for DiscordIntegrator.`;
         this.usages = [
             '!integration'
         ];

--- a/src/plugins/commander/commands/javascript.js
+++ b/src/plugins/commander/commands/javascript.js
@@ -5,8 +5,10 @@ class JavaScriptCommand extends Command {
         super(bot);
         this.aliases = ['javascript', 'js'];
 
-        this.shortdesc = 'Gives you the JavaScript role.';
-        this.desc = 'Gives you the JavaScript role if you don\'t have it, or removes it if you do.\nDeletes your message afterwards.';
+        this.shortdesc = `Gives you the JavaScript role.`;
+        this.desc = `
+            Gives you the JavaScript role if you don't have it, or removes it if you do.
+            Deletes your message afterwards.`;
         this.usages = [
             '!javascript'
         ];

--- a/src/plugins/commander/commands/lua.js
+++ b/src/plugins/commander/commands/lua.js
@@ -5,8 +5,10 @@ class LuaRoleCommand extends Command {
         super(bot);
         this.aliases = ['lua'];
 
-        this.shortdesc = 'Gives you the Lua role.';
-        this.desc = 'Gives you the Lua role if you don\'t have it, or removes it if you do.\nDeletes your message afterwards.';
+        this.shortdesc = `Gives you the Lua role.`;
+        this.desc = `
+            Gives you the Lua role if you don't have it, or removes it if you do.
+            Deletes your message afterwards.`;
         this.usages = [
             '!lua'
         ];

--- a/src/plugins/commander/commands/personalcss.js
+++ b/src/plugins/commander/commands/personalcss.js
@@ -5,8 +5,10 @@ class PersonalCSSCommand extends Command {
         super(bot);
         this.aliases = ['personalcss', 'usercss'];
 
-        this.shortdesc = 'Lists links to personal CSS pages.';
-        this.desc = 'Lists all links for personal CSS pages.\nIf a wiki is provided, links will point to it. Otherwise, dev will be used.';
+        this.shortdesc = `Lists links to personal CSS pages.`;
+        this.desc = `
+            Lists all links for personal CSS pages.
+            If a wiki is provided, links will point to it. Otherwise, dev will be used.`;
         this.usages = [
             '!personalcss [wiki]'
         ];

--- a/src/plugins/commander/commands/personaljs.js
+++ b/src/plugins/commander/commands/personaljs.js
@@ -5,8 +5,10 @@ class PersonalJSCommand extends Command {
         super(bot);
         this.aliases = ['personaljs', 'userjs'];
 
-        this.shortdesc = 'Lists links to personal JS pages.';
-        this.desc = 'Lists all links for personal JS pages.\nIf a wiki is provided, links will point to it. Otherwise, dev will be used.';
+        this.shortdesc = `Lists links to personal JS pages.`;
+        this.desc = `
+            Lists all links for personal JS pages.
+            If a wiki is provided, links will point to it. Otherwise, dev will be used.`;
         this.usages = [
             '!personaljs [wiki]'
         ];

--- a/src/plugins/commander/commands/portability.js
+++ b/src/plugins/commander/commands/portability.js
@@ -5,8 +5,10 @@ class PortabilityCommand extends Command {
         super(bot);
         this.aliases = ['portability'];
 
-        this.shortdesc = 'Gives you the Portability role.';
-        this.desc = 'Gives you the Portability role if you don\'t have it, or removes it if you do.\nDeletes your message afterwards.';
+        this.shortdesc = `Gives you the Portability role.`;
+        this.desc = `
+            Gives you the Portability role if you don't have it, or removes it if you do.
+            Deletes your message afterwards.`;
         this.usages = [
             '!portability'
         ];

--- a/src/plugins/commander/commands/quit.js
+++ b/src/plugins/commander/commands/quit.js
@@ -5,8 +5,10 @@ class QuitCommand extends OPCommand {
         super(bot);
         this.aliases = ['quit', 'q', 'destroy', 'die'];
 
-        this.shortdesc = 'Kills the bot.';
-        this.desc = 'Kills the bot, destroys the client, and stops execution.\nYou need to be a bot operator to use this command.';
+        this.shortdesc = `Kills the bot.`;
+        this.desc = `
+            Kills the bot, destroys the client, and stops execution.
+            You need to be a bot operator to use this command.`;
         this.usages = [
             '!quit'
         ];

--- a/src/plugins/commander/commands/restart.js
+++ b/src/plugins/commander/commands/restart.js
@@ -10,8 +10,10 @@ class RestartCommand extends OPCommand {
         this.hidden = true;
         this.heroku = this.bot._globalConfig.HEROKU == 'true';
 
-        this.shortdesc = 'Restarts the bot.';
-        this.desc = 'Restarts the bot.\nThe bot will send another message once the restart has finished.\nYou need to be a bot operator to use this command.';
+        this.shortdesc = `Restarts the bot.`;
+        this.desc = `
+            Restarts the bot.
+            The bot will send another message once the restart has finished.\nYou need to be a bot operator to use this command.`;
         this.usages = [
             '!restart'
         ];

--- a/src/plugins/commander/commands/rules.js
+++ b/src/plugins/commander/commands/rules.js
@@ -5,8 +5,10 @@ class RulesCommand extends Command {
         super(bot);
         this.aliases = ['rules', 'regulations'];
 
-        this.shortdesc = 'Links various regulation pages you should follow.';
-        this.desc = 'Lists various regulation pages you should follow.\nIncludes the info channel, Fandom community guidelines and Terms of Use, and Discord community guidelines and Terms of Use';
+        this.shortdesc = `Links various regulation pages you should follow.`;
+        this.desc = `
+            Lists various regulation pages you should follow.
+            Includes the info channel, Fandom community guidelines and Terms of Use, and Discord community guidelines and Terms of Use`;
         this.usages = [
             '!rules'
         ];

--- a/src/plugins/commander/commands/scripts.js
+++ b/src/plugins/commander/commands/scripts.js
@@ -5,8 +5,8 @@ class ScriptsCommand extends Command {
         super(bot);
         this.aliases = ['scripts'];
 
-        this.shortdesc = 'Posts a link to the JS enhancement index.';
-        this.desc = 'Posts a link to the JavaScript enhancement page on dev wiki.';
+        this.shortdesc = `Posts a link to the JS enhancement index.`;
+        this.desc = `Posts a link to the JavaScript enhancement page on dev wiki.`;
         this.usages = [
             '!scripts'
         ];

--- a/src/plugins/commander/commands/sitejs.js
+++ b/src/plugins/commander/commands/sitejs.js
@@ -5,8 +5,10 @@ class SiteJSCommand extends Command {
         super(bot);
         this.aliases = ['sitejs'];
 
-        this.shortdesc = 'Lists links to sitewide JS pages.';
-        this.desc = 'Lists all links for sitewide JS pages.\nIf a wiki is provided, links will point to it. Otherwise, dev will be used.';
+        this.shortdesc = `Lists links to sitewide JS pages.`;
+        this.desc = `
+            Lists all links for sitewide JS pages.
+            If a wiki is provided, links will point to it. Otherwise, dev will be used.`;
         this.usages = [
             '!sitejs [wiki]'
         ];

--- a/src/plugins/commander/commands/staff.js
+++ b/src/plugins/commander/commands/staff.js
@@ -5,8 +5,8 @@ class StaffCommand extends Command {
         super(bot);
         this.aliases = ['staff'];
 
-        this.shortdesc = 'Posts a link to Special:Contact.';
-        this.desc = 'Links to Special:Contact on Community Central, if no wiki is provided.';
+        this.shortdesc = `Posts a link to Special:Contact.`;
+        this.desc = `Links to Special:Contact on Community Central, if no wiki is provided.`;
         this.usages = [
             '!staff [wiki]'
         ];

--- a/src/plugins/commander/commands/test.js
+++ b/src/plugins/commander/commands/test.js
@@ -5,8 +5,10 @@ class TestCommand extends OPCommand {
         super(bot);
         this.aliases = ['test'];
 
-        this.shortdesc = 'Replies.';
-        this.desc = 'Replies with "Tested!", as to confirm the bot is, indeed, running.\nYou need to be an operator in order to use this command.';
+        this.shortdesc = `Replies.`;
+        this.desc = `
+            Replies with "Tested!", as to confirm the bot is, indeed, running.
+            You need to be an operator in order to use this command.`;
         this.usages = [
             '!test'
         ];

--- a/src/plugins/commander/commands/wikitext.js
+++ b/src/plugins/commander/commands/wikitext.js
@@ -5,8 +5,10 @@ class WikitextRoleCommand extends Command {
         super(bot);
         this.aliases = ['wikitext'];
 
-        this.shortdesc = 'Gives you the Wikitext role.';
-        this.desc = 'Gives you the Wikitext role if you don\'t have it, or removes it if you do.\nDeletes your message afterwards.';
+        this.shortdesc = `Gives you the Wikitext role.`;
+        this.desc = `
+            Gives you the Wikitext role if you don't have it, or removes it if you do.
+            Deletes your message afterwards.`;
         this.usages = [
             '!wikitext'
         ];


### PR DESCRIPTION
Now it
- Trims whitespace around both short and long command descriptions
- Trims whitespace on every line of the description

This allows commands to use indented template strings when defining this.desc and this.shortdesc
Additionally, this PR updates ALL commands to use template strings, resulting in easier-to-read code