### PR TITLE
Commander error reporting

### DIFF
--- a/config.sample.json
+++ b/config.sample.json
@@ -12,6 +12,8 @@
             "195712766214930432"
         ],
         "COMMANDER": {
+            "MENTION": true,
+            "INLINE_ERRORS": true,
             "PREFIXES": [
                 ">"
             ]

--- a/src/plugins/commander/index.js
+++ b/src/plugins/commander/index.js
@@ -202,9 +202,14 @@ class Commander {
         } catch(e) {
             const lines = e.stack.split('\n'),
             firstRelevant = lines.findIndex(line => line.includes('Commander.callCommand')),
-            relevantLines = lines.slice(0, firstRelevant);
+            relevantLines = lines.slice(0, firstRelevant),
+            errorMessage = `${command.constructor.name}CallError: ${relevantLines.join('\n')}`;
 
-            this.bot.logger.log('commander', `${command.constructor.name}CallError: ${relevantLines.join('\n')}`);
+            this.bot.logger.log('commander', errorMessage);
+
+            if (this.config.INLINE_ERRORS) {
+                message.channel.send('```apache\n' + errorMessage + '```');
+            }
         }
     }
 }


### PR DESCRIPTION
If config.COMMANDER.INLINE_ERRORS is set to `true`, any errors encountered during command executions will be reported with a full relevant stack trace to the channel.