### PR TITLE
Update !git author.url

### DIFF
--- a/src/plugins/commander/commands/code.js
+++ b/src/plugins/commander/commands/code.js
@@ -106,12 +106,18 @@ class CodeCommand extends Command {
         }
 
         const commitMessage = this.bot.fmt.firstLine(info.lastCommit.message);
+        const pullId = commitMessage.match(/#(\d+)/);
+        const updateUrl = pullId
+            ? `${info.url}/pull/${pullId[1]}`
+            : `${info.url}/commits/${info.lastCommit.sha}`;
+
+        console.log(info.lastCommit, updateUrl);
 
         message.channel.send({
             embed: {
                 author: {
                     name: info.path,
-                    url: info.url,
+                    url: updateUrl,
                 },
                 url: info.url,
                 title: `Click here to view source code on ${info.sitename}`,
@@ -225,11 +231,12 @@ class CodeCommand extends Command {
                 const commit = commits[0];
                 if (commit) {
                     data.lastCommit = {
+                        sha: commit.sha,
+                        message: commit.commit.message,
                         author: {
                             name: commit.author.login,
                             icon: commit.author.avatar_url
                         },
-                        message: commit.commit.message
                     };
                 }
 

--- a/src/plugins/fmt/index.js
+++ b/src/plugins/fmt/index.js
@@ -16,7 +16,7 @@ class Formatter {
     }
 
     firstLine(str) {
-        return str.trim().match(/^.*/);
+        return str.trim().match(/^.*/)[0];
     }
 
     trimLines(str) {


### PR DESCRIPTION
- The author url no longer points to the repo, and instead points to the latest commit url
- If the commit references a #number, it will link to that PR instead
- I need to figure out a way to disambiguate whether it's a PR or an issue. Atm, it assumes it will always be /pull/$id
- Extra: Fixes fmt.firstLine return type from regular expression match object to string