### PR TITLE
Ignore self

### DIFF
--- a/src/plugins/automod/index.js
+++ b/src/plugins/automod/index.js
@@ -23,7 +23,12 @@ class AutoMod {
     }
 
     onMessage(message) {
-        if (!message.member) return;
+        // Ignore bots and self, and if there isn't a member property
+        if (
+            !message.member ||
+            message.author.bot ||
+            message.author.id == this.bot.client.user.id
+        ) return;
 
         this.filters.forEach(async (filter) => {
             const interest = filter.interested(message);

--- a/src/plugins/commander/index.js
+++ b/src/plugins/commander/index.js
@@ -125,6 +125,12 @@ class Commander {
     }
 
     async onMessage(message) {
+        // Ignore bots and self
+        if (
+            message.author.bot ||
+            message.author.id == this.bot.client.user.id
+        ) return;
+
         let text = message.content.trim(),
         prefixes = await this.getPrefixes(message.guild),
         i = prefixes.length;

--- a/src/plugins/quoter/index.js
+++ b/src/plugins/quoter/index.js
@@ -33,6 +33,12 @@ class Quoter {
     }
 
     async onMessage(message) {
+        // Ignore bots and self
+        if (
+            message.author.bot ||
+            message.author.id == this.bot.client.user.id
+        ) return;
+
         const quotes = this.matchQuotes(message.content);
         if (!quotes.length) return;
 


### PR DESCRIPTION
Updates multiple plugins to make sure they ignore when the actions are performed by bots or the current account. Second check is negligible, as it's always a bot, but who knows who'll selfbot in the future.