### PR TITLE
Quote format touch-ups

### DIFF
--- a/src/plugins/quoter/index.js
+++ b/src/plugins/quoter/index.js
@@ -68,7 +68,7 @@ class Quoter {
 
         for (const i in filtered) {
             const quote = filtered[i],
-            embed = this.buildQuoteEmbed(message, quote);
+            embed = this.buildQuoteEmbed(message, quote, i === '0'); // Go figure, array indices when for..in are strings!
 
             if (!embed) continue;
 
@@ -105,10 +105,10 @@ class Quoter {
         }
     }
 
-    buildQuoteEmbed(message, quote) {
+    buildQuoteEmbed(message, quote, includeQuoter) {
         const sameChannel = message.channel.id === quote.channel.id;
         const sameGuild = message.guild.id === quote.guild.id;
-        let name = quote.member && quote.member.nickname || quote.author.username
+        let text = quote.member && quote.member.nickname || quote.author.username
 
         if (!sameChannel) {
             if (sameGuild) {
@@ -132,18 +132,22 @@ class Quoter {
             ? quote.attachments.first()
             : quote.embeds[0] && quote.embeds[0].image;
 
+        const author = includeQuoter
+            ? {
+                icon_url: message.author.displayAvatarURL,
+                name: `Quoted by ${message.author.username}#${message.author.discriminator}`
+            }
+            : undefined;
+
         return {
-            author: {
-                icon_url: quote.author.displayAvatarURL,
-                name
-            },
+            author,
             // title: 'Click to jump',
             // url: `https://discordapp.com/channels/${quote.guild.id}/${quote.channel.id}/${quote.id}`,
             description,
             image: image || undefined,
             footer: {
-                icon_url: message.author.displayAvatarURL,
-                text: `Quoted by ${message.author.username}#${message.author.discriminator}`
+                icon_url: quote.author.displayAvatarURL,
+                text
             },
             timestamp: quote.createdAt.toISOString()
         };


### PR DESCRIPTION
- Switch quoted by and quote author fields (footer and author, respectively), due to previously the quote timestamp being in the opposite place from its actual author
- Now that the quoter's name is at the top of the embed, skip the field on 2nd, 3rd, ... embeds from the same message
New quote format is:
```
<quoted by>
<Click to jump>

[content/embed]
[image]
<quote author> • <quote timestamp>
```