### PR TITLE
Implement plugin/command blacklist/whitelist.

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,6 +4,8 @@ const client = new Twinkle();
 
 client.loadPluginDir(path.join(__dirname, 'src', 'plugins'));
 
-client.commander.loadCommandDir(path.join(__dirname, 'src', 'plugins', 'commander', 'commands'));
+if (client.commander) {
+    client.commander.loadCommandDir(path.join(__dirname, 'src', 'plugins', 'commander', 'commands'));
+}
 
 client.login(client.config.TOKEN);

--- a/src/Twinkle.js
+++ b/src/Twinkle.js
@@ -33,8 +33,16 @@ class Twinkle {
     }
 
     loadPluginDir(dir) {
+        const wl = this.config.PLUGINS.WHITELIST;
+        const bl = this.config.PLUGINS.BLACKLIST;
         fs.readdirSync(dir).forEach(file => {
             const p = path.join(dir, file);
+            if (wl instanceof Array && !wl.includes(file)) {
+                return;
+            }
+            if (bl instanceof Array && bl.includes(file)) {
+                return;
+            }
             const Plugin = require(p);
             this.loadPlugin(Plugin);
         });

--- a/src/plugins/commander/index.js
+++ b/src/plugins/commander/index.js
@@ -72,8 +72,17 @@ class Commander {
     }
 
     loadCommandDir(dir) {
+        const wl = this.config.WHITELIST;
+        const bl = this.config.BLACKLIST;
         fs.readdirSync(dir).forEach(file => {
             const p = path.join(dir, file);
+            const name = file.replace(/\.js$/, '');
+            if (wl instanceof Array && !wl.includes(name)) {
+                return;
+            }
+            if (bl instanceof Array && bl.includes(name)) {
+                return;
+            }
             try {
                 const Command = require(p);
                 this.loadCommand(Command, file.slice(0, -3));


### PR DESCRIPTION
Four new configuration options have been implemented:
- `TWINKLE.PLUGINS.BLACKLIST`
- `TWINKLE.PLUGINS.WHITELIST`
- `TWINKLE.COMMANDER.BLACKLIST`
- `TWINKLE.COMMANDER.WHITELIST`

These allow blacklisting/whitelisting certain plugins/commands from being loaded on start. Blacklisted/non-whitelisted plugins may still be loaded if other plugins are requesting them as dependencies or through other means.