### PR TITLE
Handle error when the guild members intent is disabled in the preload plugin.

### DIFF
--- a/src/plugins/preload/index.js
+++ b/src/plugins/preload/index.js
@@ -22,7 +22,11 @@ class Preload {
 		const guild = await this.bot.client.guilds.fetch(guildId);
 		if (!guild) return;
 
-		guild.members.fetch();
+		try {
+			await guild.members.fetch();
+		} catch (error) {
+			console.error('Failed to preload guild', guildId, 'have you enabled the guild members intent?', error);
+		}
 	}
 }
 


### PR DESCRIPTION
In ThE fUtUrE, pRoMiSe ReJeCtIoNs ThAt ArE nOt HaNdLeD wIlL tErMiNaTe ThE nOdE.jS pRoCeSs WiTh A nOn-ZeRo ExIt CoDe.