### PR TITLE
Restart process improvements.

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,3 +1,4 @@
+#!/usr/bin/env node
 const path = require('path');
 const Twinkle = require('./src/Twinkle.js');
 const client = new Twinkle();

--- a/src/plugins/commander/commands/restart.js
+++ b/src/plugins/commander/commands/restart.js
@@ -1,13 +1,15 @@
+const { HEROKU } = require('../../../../config.json');
 const { spawn } = require('child_process');
+const fs = require('fs');
 const got = require('got');
 const OPCommand = require('../structs/OPCommand.js');
 const DatabasePlugin = require('../../db');
 
 class RestartCommand extends OPCommand {
     static get deps() {
-        return [
+        return HEROKU == 'true' ? [
             DatabasePlugin
-        ];
+        ] : [];
     }
 
     constructor(bot) {
@@ -15,6 +17,7 @@ class RestartCommand extends OPCommand {
         this.aliases = ['restart', 'r'];
         this.hidden = true;
         this.heroku = this.bot._globalConfig.HEROKU == 'true';
+        this.systemd = this.bot._globalConfig.SYSTEMD;
 
         this.shortdesc = `Restarts the bot.`;
         this.desc = `
@@ -27,20 +30,20 @@ class RestartCommand extends OPCommand {
     }
 
     async call(message) {
-        await Promise.all([
-            message.channel.send('Restarting...'),
-            // TODO: Make db writes return usable promises
-            this.bot.db.set('lastRestartChannel', message.channel.id)
-        ]);
-
+        const channelId = message.channel.id;
+        await message.channel.send('Restarting...');
         if (this.heroku) {
-            this.restartHeroku();
+            await this.restartHeroku(channelId);
+        } else if (this.systemd) {
+            await this.restartSystemd(channelId);
         } else {
-            this.restartProc();
+            this.restartProc(channelId);
         }
     }
 
-    async restartHeroku() {
+    async restartHeroku(channelId) {
+        // TODO: Make db writes return usable promises
+        await this.bot.db.set('lastRestartChannel', channelId);
         const config = this.bot._globalConfig;
         const name = config.IS_BACKUP ? config.BACKUP_APP_NAME : config.APP_NAME;
         const token = config.HEROKU_TOKEN;
@@ -60,14 +63,25 @@ class RestartCommand extends OPCommand {
         });
     }
 
-    restartProc() {
-        const subprocess = spawn(process.argv0, process.argv.slice(1), {
-            detached: true,
-            stdio: 'ignore'
-        });
+    restartProc(channelId) {
+        const subprocess = spawn(
+            process.argv0,
+            process.argv.slice(1)
+                .filter(arg => !arg.startsWith('--last-restart-channel'))
+                .concat([`--last-restart-channel=${channelId}`]),
+            {
+                detached: true,
+                stdio: 'ignore'
+            }
+        );
         subprocess.unref();
 
         process.exit(0);
+    }
+
+    async restartSystemd(channelId) {
+        await fs.promises.writeFile('/tmp/twinkle.chan', channelId);
+        process.exit(1);
     }
 }
 

--- a/src/plugins/commander/commands/restart.js
+++ b/src/plugins/commander/commands/restart.js
@@ -1,4 +1,4 @@
-const { HEROKU } = require('../../../../config.json');
+const { HEROKU, SYSTEMD } = require('../../../../config.json');
 const { spawn } = require('child_process');
 const fs = require('fs');
 const got = require('got');
@@ -7,7 +7,7 @@ const DatabasePlugin = require('../../db');
 
 class RestartCommand extends OPCommand {
     static get deps() {
-        return HEROKU == 'true' ? [
+        return (HEROKU == 'true' || SYSTEMD) ? [
             DatabasePlugin
         ] : [];
     }
@@ -80,7 +80,7 @@ class RestartCommand extends OPCommand {
     }
 
     async restartSystemd(channelId) {
-        await fs.promises.writeFile('/tmp/twinkle.chan', channelId);
+        await this.bot.db.set('lastRestartChannel', channelId);
         process.exit(1);
     }
 }

--- a/src/plugins/restartnotify/index.js
+++ b/src/plugins/restartnotify/index.js
@@ -1,11 +1,17 @@
 const Plugin = require('../../structs/Plugin.js');
 const DatabasePlugin = require('../db');
 
+const lastRestartChannelCmd = process.argv
+    .map(arg => arg.split('='))
+    .find(arg => arg[0] === '--last-restart-channel');
+
 class RestartNotifyPlugin extends Plugin {
     static get deps() {
-        return [
-            DatabasePlugin
-        ];
+        return lastRestartChannelCmd ?
+            [] :
+            [
+                DatabasePlugin
+            ];
     }
 
     load() {
@@ -20,10 +26,14 @@ class RestartNotify {
     }
 
     async onReady() {
-        const channelId = await this.bot.db.get('lastRestartChannel');
-        if (!channelId) return;
-
-        this.bot.db.delete('lastRestartChannel');
+        let channelId;
+        if (lastRestartChannelCmd) {
+            channelId = lastRestartChannelCmd[1];
+        } else {
+            channelId = await this.bot.db.get('lastRestartChannel');
+            if (!channelId) return;
+            this.bot.db.delete('lastRestartChannel');
+        }
 
         const channel = await this.bot.client.channels.fetch(channelId);
         if (!channel) return;


### PR DESCRIPTION
Three major improvements in this pull request:
- Twinkle now supports restarting via systemd (and other process managers that rely on the exit code not being 0 to restart the process). This can be configured by setting the `SYSTEMD` option to `true`.
- FSTransport now works.
- When restarting without Heroku/systemd support, the database isn't required as Twinkle will restart using a command-line argument.

An example systemd unit file for Twinkle follows.
```ini
[Unit]
After=network.target
Description=Twinkle bot instance for development
Documentation=https://github.com/Dorumin/Twinkle

[Service]
ExecStart=/home/perapisar/Projects/Other/Twinkle/index.js
Restart=on-failure
RestartSec=1
Type=simple
WorkingDirectory=/home/perapisar/Projects/Other/Twinkle
StandardOutput=append:/home/perapisar/Projects/Other/Twinkle/systemd.log
StandardError=append:/home/perapisar/Projects/Other/Twinkle/systemd.err

[Install]
WantedBy=default.target
```