### PR TITLE
discord.js v13, error and SIGINT handling

### DIFF
--- a/index.js
+++ b/index.js
@@ -12,7 +12,5 @@ if (client.commander) {
 
 client.login(client.config.TOKEN);
 
-process.on('unhandledRejection', function(reason) {
-    console.error('Unhandled rejection:', reason);
-});
+process.on('unhandledRejection', client.unhandledRejection.bind(client));
 process.on('SIGINT', client.cleanup.bind(client));

--- a/index.js
+++ b/index.js
@@ -1,4 +1,5 @@
 #!/usr/bin/env node
+require('events').captureRejections = true;
 const path = require('path');
 const Twinkle = require('./src/Twinkle.js');
 const client = new Twinkle();
@@ -10,3 +11,8 @@ if (client.commander) {
 }
 
 client.login(client.config.TOKEN);
+
+process.on('unhandledRejection', function(reason) {
+    console.error('Unhandled rejection:', reason);
+});
+process.on('SIGINT', client.cleanup.bind(client));

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "twinklebot",
-  "version": "0.0.1",
+  "version": "0.0.3",
   "description": "Fandom Developers Discord bot",
   "main": "index.js",
   "scripts": {
@@ -16,20 +16,20 @@
     "url": "https://github.com/Dorumin/Twinkle/issues"
   },
   "engines": {
-    "node": ">=12.14.1"
+    "node": ">=16"
   },
   "homepage": "https://github.com/Dorumin/Twinkle#readme",
   "dependencies": {
-    "clean-stack": "2.2.0",
+    "clean-stack": "^4.1.0",
     "confusables": "^1.0.0",
-    "diff": "^4.0.2",
-    "discord.js": "^12.3.1",
-    "dropbox": "4.0.30",
-    "got": "^10.3.0",
+    "diff": "^5.0.0",
+    "discord.js": "^13.0.1",
+    "dropbox": "^10.5.0",
+    "got": "^11.8.2",
     "he": "^1.2.0",
     "node-fetch": "^2.6.1",
-    "node-html-parser": "^3.1.3",
+    "node-html-parser": "^4.1.3",
     "recursive-readdir": "^2.2.2",
-    "tough-cookie": "3.0.1"
+    "tough-cookie": "^4.0.0"
   }
 }

--- a/src/Twinkle.js
+++ b/src/Twinkle.js
@@ -24,9 +24,7 @@ class Twinkle {
                 // Listening for commands in DM
                 Intents.FLAGS.DIRECT_MESSAGES,
                 // Reactions on commands like !help
-                Intents.FLAGS.DIRECT_MESSAGE_REACTIONS,
-                // Guild invites for JoinLeave
-                Intents.FLAGS.GUILD_INVITES
+                Intents.FLAGS.DIRECT_MESSAGE_REACTIONS
             ].concat(config.TWINKLE.INTENTS || [])
         });
         this.config = config.TWINKLE;
@@ -124,10 +122,9 @@ class Twinkle {
 
     async cleanup() {
         for (const plugin of this.loadedPlugins) {
-            if (plugin.cleanup) {
-                await plugin.cleanup();
-            }
+            await plugin.cleanup();
         }
+
         this.client.destroy();
     }
 }

--- a/src/Twinkle.js
+++ b/src/Twinkle.js
@@ -24,7 +24,9 @@ class Twinkle {
                 // Listening for commands in DM
                 Intents.FLAGS.DIRECT_MESSAGES,
                 // Reactions on commands like !help
-                Intents.FLAGS.DIRECT_MESSAGE_REACTIONS
+                Intents.FLAGS.DIRECT_MESSAGE_REACTIONS,
+                // Guild invites for JoinLeave
+                Intents.FLAGS.GUILD_INVITES
             ].concat(config.TWINKLE.INTENTS || [])
         });
         this.config = config.TWINKLE;
@@ -97,7 +99,11 @@ class Twinkle {
             }
             const channel = this.client.channels.cache.get(this.config.REPORTING.CHANNEL);
             if (channel) {
-                await channel.send(newMessage);
+                try {
+                    await channel.send(newMessage);
+                } catch(e) {
+                    // Discard error, instance might be destroyed
+                }
             }
         }
     }
@@ -105,7 +111,7 @@ class Twinkle {
     unhandledRejection(reason) {
         return this.reportError('Unhanded rejection:', reason);
     }
-    
+
     wrapListener(listener, context) {
         return function(arg) {
             try {

--- a/src/Twinkle.js
+++ b/src/Twinkle.js
@@ -124,7 +124,9 @@ class Twinkle {
 
     async cleanup() {
         for (const plugin of this.loadedPlugins) {
-            await plugin.cleanup();
+            if (plugin.cleanup) {
+                await plugin.cleanup();
+            }
         }
         this.client.destroy();
     }

--- a/src/plugins/automod/filters/BadWords.js
+++ b/src/plugins/automod/filters/BadWords.js
@@ -44,7 +44,7 @@ class BadWordsFilter extends Filter {
             if (error && error.code === 50007) {
                 logMessage += '\nUser blocked DMs.';
             } else {
-                console.error('Failed to warn user:', error);
+                await this.automod.bot.reportError('Failed to warn user:', error);
                 logMessage += '\nFailed to warn user.';
             }
         }

--- a/src/plugins/automod/filters/BadWords.js
+++ b/src/plugins/automod/filters/BadWords.js
@@ -30,24 +30,36 @@ class BadWordsFilter extends Filter {
 
     async handle(message) {
         const muteAction = message.member.roles.add('401231955741507604');
-        message.author.send(`Hey! Watch your language! You've been grounded from ${message.guild.name}; message someone with the **@Server Moderator** role to talk this out.`); // TODO # of offenses
-        message.author.send(`Here's a copy of your message:\`\`\`${message.content}\`\`\``);
-        message.delete();
+        const muteResult = await muteAction.then(() => 'and muted', () => 'but could not be muted');
+        await message.delete();
 
         const patternsDesc = describeMatchedPatterns('\nThe following patterns were matched:\n', this.patterns, message.content);
         const postCcnormPatternsDesc = describeMatchedPatterns('\nThe following post-ccnorm patterns were matched:\n', this.postCcnormPatterns, remove(message.content));
 
-        const muteResult = await muteAction.then(() => 'and muted', () => 'but could not be muted');
-        (await this.automod.logchan() || message.channel).send({
-            embed: {
+        let logMessage = `**Reason**: Bad words matched${patternsDesc}${postCcnormPatternsDesc}\n<@${message.author.id}>`; // TODO: # of offenses
+        try {
+            await message.author.send(`Hey! Watch your language! You've been grounded from ${message.guild.name}; message someone with the **@Server Moderator** role to talk this out.`); // TODO # of offenses
+            await message.author.send(`Here's a copy of your message:\`\`\`${message.content.slice(0, 1900)}\`\`\``);    
+        } catch (error) {
+            if (error && error.code === 50007) {
+                logMessage += '\nUser blocked DMs.';
+            } else {
+                console.error('Failed to warn user:', error);
+                logMessage += '\nFailed to warn user.';
+            }
+        }
+
+        await (await this.automod.logchan() || message.channel).send({
+            embeds: [{
                 author: {
-                    name: `${message.author.username}#${message.author.discriminator} has been warned ${muteResult}`,
+                    name: `${message.author.tag} has been warned ${muteResult}`,
                     icon_url: message.author.displayAvatarURL()
                 },
                 color: message.guild.me.displayColor,
-                description: `**Reason**: Bad words matched${patternsDesc}${postCcnormPatternsDesc}\n<@${message.author.id}>`, // TODO: # of offenses
-            }
+                description: logMessage
+            }]
         });
+
     }
 }
 

--- a/src/plugins/automod/filters/Flood.js
+++ b/src/plugins/automod/filters/Flood.js
@@ -48,7 +48,7 @@ class FloodFilter extends Filter {
             if (error && error.code === 50007) {
                 logMessage += '\nUser blocked DMs.';
             } else {
-                console.error('Failed to warn user:', error);
+                await this.automod.bot.reportError('Failed to warn user:', error);
                 logMessage += '\nFailed to warn user.';
             }
         }

--- a/src/plugins/automod/filters/Invites.js
+++ b/src/plugins/automod/filters/Invites.js
@@ -52,7 +52,7 @@ class InvitesFilter extends Filter {
             if (error && error.code === 50007) {
                 logMessage += '\nUser blocked DMs.';
             } else {
-                console.error('Failed to warn user:', error);
+                await this.automod.bot.reportError('Failed to warn user:', error);
                 logMessage += '\nFailed to warn user.';
             }
         }

--- a/src/plugins/automod/filters/MassMention.js
+++ b/src/plugins/automod/filters/MassMention.js
@@ -38,7 +38,7 @@ class MassMentionFilter extends Filter {
             if (error && error.code === 50007) {
                 logMessage += '\nUser blocked DMs.';
             } else {
-                console.error('Failed to warn user:', error);
+                await this.automod.bot.reportError('Failed to warn user:', error);
                 logMessage += '\nFailed to warn user.';
             }
         }

--- a/src/plugins/automod/filters/Zalgo.js
+++ b/src/plugins/automod/filters/Zalgo.js
@@ -11,8 +11,8 @@ class ZalgoFilter extends Filter {
     interested(message) {
         if (message.member.permissions.has('MANAGE_MESSAGES')) return false;
 
-        let i = message.content.length,
-        min = this.min;
+        let i = message.content.length;
+        let min = this.min;
 
         while (i-- && min) {
             let code = message.content.charCodeAt(i);
@@ -27,19 +27,31 @@ class ZalgoFilter extends Filter {
 
     async handle(message) {
         const muteAction = message.member.roles.add('401231955741507604');
-        message.author.send(`Hey! Please don't abuse zalgo/spammy text in ${message.guild.name}.`); // TODO # of offenses
-        message.delete();
-
         const muteResult = await muteAction.then(() => 'and muted', () => 'but could not be muted');
-        (await this.automod.logchan() || message.channel).send({
-            embed: {
+
+        await message.delete();
+
+        let logMessage = `**Reason**: Zalgo usage\n<@${message.author.id}>`; // TODO: # of offenses
+        try {
+            await message.author.send(`Hey! Please don't abuse zalgo/spammy text in ${message.guild.name}.`); // TODO # of offenses
+        } catch (error) {
+            if (error && error.code === 50007) {
+                logMessage += '\nUser blocked DMs.';
+            } else {
+                console.error('Failed to warn user:', error);
+                logMessage += '\nFailed to warn user.';
+            }
+        }
+
+        await (await this.automod.logchan() || message.channel).send({
+            embeds: [{
                 author: {
-                    name: `${message.author.username}#${message.author.discriminator} has been warned ${muteResult}`,
+                    name: `${message.author.tag} has been warned ${muteResult}`,
                     icon_url: message.author.displayAvatarURL()
                 },
                 color: message.guild.me.displayColor,
-                description: `**Reason**: Zalgo usage\n<@${message.author.id}>`, // TODO: # of offenses
-            }
+                description: logMessage
+            }]
         });
     }
 }

--- a/src/plugins/automod/filters/Zalgo.js
+++ b/src/plugins/automod/filters/Zalgo.js
@@ -38,7 +38,7 @@ class ZalgoFilter extends Filter {
             if (error && error.code === 50007) {
                 logMessage += '\nUser blocked DMs.';
             } else {
-                console.error('Failed to warn user:', error);
+                await this.automod.bot.reportError('Failed to warn user:', error);
                 logMessage += '\nFailed to warn user.';
             }
         }

--- a/src/plugins/automod/index.js
+++ b/src/plugins/automod/index.js
@@ -15,7 +15,7 @@ class AutoMod {
             return new Filter(this);
         });
 
-        bot.client.on('messageCreate', this.onMessage.bind(this));
+        bot.client.on('messageCreate', bot.wrapListener(this.onMessage, this));
     }
 
     logchan() {
@@ -47,7 +47,7 @@ class AutoMod {
                     result = await interest;
                 } catch (error) {
                     result = false;
-                    console.error('Failed to fetch interest:', error);
+                    await this.bot.reportError('Failed to fetch interest:', error);
                 }
             } else {
                 result = interest;
@@ -57,7 +57,7 @@ class AutoMod {
                 try {
                     filter.handle(message);
                 } catch (error) {
-                    console.error('Failed to handle message:', error);
+                    await this.bot.reportError('Failed to handle message:', error);
                 }
             }
         });

--- a/src/plugins/automod/index.js
+++ b/src/plugins/automod/index.js
@@ -15,7 +15,7 @@ class AutoMod {
             return new Filter(this);
         });
 
-        bot.client.on('message', this.onMessage.bind(this));
+        bot.client.on('messageCreate', this.onMessage.bind(this));
     }
 
     logchan() {
@@ -33,7 +33,7 @@ class AutoMod {
 
         // Fetch members not already in member cache
         if (!message.member) {
-            const member = await message.guild.fetchMember(message.author.id);
+            const member = await message.guild.members.fetch(message.author.id);
 
             message.member = member;
         }
@@ -43,13 +43,22 @@ class AutoMod {
             let result;
 
             if (interest instanceof Promise) {
-                result = await interest;
+                try {
+                    result = await interest;
+                } catch (error) {
+                    result = false;
+                    console.error('Failed to fetch interest:', error);
+                }
             } else {
                 result = interest;
             }
 
             if (result) {
-                filter.handle(message);
+                try {
+                    filter.handle(message);
+                } catch (error) {
+                    console.error('Failed to handle message:', error);
+                }
             }
         });
     }

--- a/src/plugins/commander/commands/ask.js
+++ b/src/plugins/commander/commands/ask.js
@@ -16,7 +16,7 @@ class AskCommand extends Command {
         message.channel.send(`
 Please don't ask if you may ask or ask for people who "know" x, y, or z. Just ask your question and somebody may be able to answer it.
 <https://sol.gfxile.net/dontask.html>
-        `)
+        `);
     }
 }
 

--- a/src/plugins/commander/commands/clear.js
+++ b/src/plugins/commander/commands/clear.js
@@ -170,7 +170,7 @@ class ClearCommand extends ModCommand {
                 }
             }).json();    
         } catch (error) {
-            console.error('Failed to check whether the message exists:', error, error.response);
+            await this.bot.reportError('Failed to check whether the message exists:', error.response);
             return false;
         }
 
@@ -336,7 +336,7 @@ class ClearCommand extends ModCommand {
             try {
                 await channel.bulkDelete(chunks[i]);
             } catch(e) {
-                console.error('Bulk deletion error', e);
+                await this.bot.reportError('Bulk deletion error', e);
                 failures += chunks[i].length;
             }
         }
@@ -369,15 +369,15 @@ class ClearCommand extends ModCommand {
 
                 if (res == 'timeout') throw 'timeout';
                 break;
-            } catch(e) {
-                if (e != 'timeout') {
-                    console.error(e);
+            } catch (e) {
+                if (e !== 'timeout') {
+                    await this.bot.reportError('Deleting messages failed:', e);
                 }
 
                 retries--;
 
                 if (retries < 1) {
-                    console.error(`Errored too much: ${messageId}`);
+                    await this.bot.reportError(`Errored too much (${messageId}):`, e);
                     return false;
                 }
 

--- a/src/plugins/commander/commands/code.js
+++ b/src/plugins/commander/commands/code.js
@@ -21,13 +21,13 @@ class CodeCommand extends Command {
     }
 
     call(message) {
-        message.channel.send(`${this.bot.fmt.bold('Give us your code!')} This makes debugging way easier.
+        return message.channel.send(`${this.bot.fmt.bold('Give us your code!')} This makes debugging way easier.
 You can use:
  - codeblocks:
 \\\`\\\`\\\`lang
 // short block of code
 \\\`\\\`\\\`
- - a link to your Fandom/Github file
+ - a link to your Fandom/GitHub file
  - a code snippet site:
 <https://gist.github.com/> • <https://hastebin.com/> • <https://privatebin.net/> • <https://ghostbin.com/> • <https://pastebin.com/>
 Please *don't* use screenshots, we can't read those!`);

--- a/src/plugins/commander/commands/css.js
+++ b/src/plugins/commander/commands/css.js
@@ -14,14 +14,14 @@ class CSSRoleCommand extends Command {
         ];
     }
 
-    call(message, content) {
+    async call(message, content) {
         if (content) return;
 
-        message.delete();
+        await message.delete();
         if (message.member.roles.cache.has('269869854440423429')) {
-            message.member.roles.remove('269869854440423429');
+            return message.member.roles.remove('269869854440423429');
         } else {
-            message.member.roles.add('269869854440423429');
+            return message.member.roles.add('269869854440423429');
         }
     }
 }

--- a/src/plugins/commander/commands/eval.js
+++ b/src/plugins/commander/commands/eval.js
@@ -147,7 +147,7 @@ class EvalCommand extends OPCommand {
             // This is a HACK to essentially send a message on another thread
             // I use curl because I can't be assed to spawn a small js file to post with got
             // I tried to make this look as pretty as possible
-            const url = `https://discord.com/api/v6/channels/${channel.id}/messages`;
+            const url = `https://discord.com/api/v9/channels/${channel.id}/messages`;
             const body = JSON.stringify({
                 content: `Dynamically loading ${name}...`
             });
@@ -319,17 +319,12 @@ class EvalCommand extends OPCommand {
 
     getVars(message) {
         return {
-            send: (...args) => {
+            send: (arg) => {
                 if (
-                    args[0] &&
-                    (
-                        args.length !== 1
-                        || args[0].embed
-                        || args[0].files
-                        || args[0] instanceof MessageEmbed
-                    )
+                    arg &&
+                    (arg.embed || arg.files || arg instanceof MessageEmbed)
                 ) {
-                    const promise = message.channel.send(...args);
+                    const promise = message.channel.send(arg);
 
                     this.ignoredObjects.push(promise);
                     promise.then(message => this.ignoredObjects.push(message));
@@ -337,7 +332,7 @@ class EvalCommand extends OPCommand {
                     return promise;
                 }
 
-                const promise = this.respond(args[0], {
+                const promise = this.respond(arg, {
                     channel: message.channel
                 });
 
@@ -610,11 +605,11 @@ class EvalCommand extends OPCommand {
         const { channel, message: originalMessage } = context;
 
         if (result === null) {
-            return await channel.send('null');
+            return channel.send('null');
         }
 
         if (Number.isNaN(result)) {
-            return await channel.send('NaN');
+            return channel.send('NaN');
         }
 
         if (typeof result === 'undefined') {
@@ -622,7 +617,7 @@ class EvalCommand extends OPCommand {
             // async payloads that are longer than one expression
             if (code && code.isAsync && !code.isExpression) return;
 
-            return await channel.send('undefined');
+            return channel.send('undefined');
         }
 
         if (this.ignoredObjects.includes(result)) {
@@ -630,20 +625,20 @@ class EvalCommand extends OPCommand {
         }
 
         if (typeof result === 'bigint') {
-            return await this.sendExpand(channel, `${result}n`);
+            return this.sendExpand(channel, `${result}n`);
         }
 
         if (typeof result === 'string') {
             // Send smol code block with "" for empty strings
             if (result === '') {
-                return await this.sendExpand(channel, `""`, 'js')
+                return this.sendExpand(channel, `""`, 'js')
             } else {
-                return await this.sendExpand(channel, result);
+                return this.sendExpand(channel, result);
             }
         }
 
         if (['symbol', 'number'].includes(typeof result)) {
-            return await this.sendExpand(channel, String(result));
+            return this.sendExpand(channel, String(result));
         }
 
         if (typeof result === 'function') {
@@ -658,21 +653,21 @@ class EvalCommand extends OPCommand {
                     .join('\n');
             }
 
-            return await this.sendExpand(channel, indented, 'js');
+            return this.sendExpand(channel, indented, 'js');
         }
 
         if (result instanceof Error) {
             const inspection = this.inspect(result);
 
-            return await this.sendExpand(channel, inspection.text(), 'apache');
+            return this.sendExpand(channel, inspection.text(), 'apache');
         }
 
         if (result instanceof Date) {
-            return await channel.send(result.toUTCString());
+            return channel.send(result.toUTCString());
         }
 
         if (result instanceof MessageEmbed) {
-            return await channel.send(result);
+            return channel.send(result);
         }
 
         if (result instanceof Promise) {
@@ -737,15 +732,13 @@ class EvalCommand extends OPCommand {
         let botReaction = await message.react('👁️');
 
         while (true) {
-            const reactions = await message.awaitReactions(
-                (reaction, user) =>
+            const reactions = await message.awaitReactions({
+                filter: (reaction, user) =>
                     reaction.emoji.name === botReaction.emoji.name &&
                     user.id === originalMessage.author.id,
-                {
-                    max: 1,
-                    time: 30000
-                }
-            );
+                max: 1,
+                time: 30000
+            });
 
             if (reactions.size === 0) {
                 try {

--- a/src/plugins/commander/commands/github.js
+++ b/src/plugins/commander/commands/github.js
@@ -7,6 +7,8 @@ const readdir = require('recursive-readdir');
 const Command = require('../structs/Command.js');
 const Cache = require('../../../structs/Cache.js');
 const FormatterPlugin = require('../../fmt');
+const {promisify} = require('util');
+const wait = promisify(setTimeout);
 
 class GitHubCommand extends Command {
     static get deps() {
@@ -54,7 +56,7 @@ class GitHubCommand extends Command {
         if (lines) {
             fields.push({
                 name: 'Lines of code',
-                value: lines,
+                value: String(lines),
                 inline: true,
             });
         }
@@ -82,7 +84,7 @@ class GitHubCommand extends Command {
         if (info.watchers) {
             fields.push({
                 name: 'Watchers',
-                value: info.watchers,
+                value: String(info.watchers),
                 inline: true,
             });
         }
@@ -90,7 +92,7 @@ class GitHubCommand extends Command {
         if (info.stars) {
             fields.push({
                 name: 'Stargazers',
-                value: info.stars,
+                value: String(info.stars),
                 inline: true,
             });
         }
@@ -98,7 +100,7 @@ class GitHubCommand extends Command {
         if (info.issues) {
             fields.push({
                 name: 'Open issues',
-                value: info.issues,
+                value: String(info.issues),
                 inline: true,
             });
         }
@@ -106,7 +108,7 @@ class GitHubCommand extends Command {
         if (info.forks) {
             fields.push({
                 name: 'Forks',
-                value: info.forks,
+                value: String(info.forks),
                 inline: true,
             });
         }
@@ -117,8 +119,8 @@ class GitHubCommand extends Command {
             ? `${info.url}/pull/${pullId[1]}`
             : `${info.url}/commit/${info.lastCommit.sha}`;
 
-        message.channel.send({
-            embed: {
+        return message.channel.send({
+            embeds: [{
                 author: {
                     name: info.path,
                     url: updateUrl,
@@ -132,7 +134,7 @@ class GitHubCommand extends Command {
                     text: `${commitMessage} - ${info.lastCommit.author.name}`,
                     icon_url: info.lastCommit.author.icon
                 }
-            }
+            }]
         });
     }
 
@@ -171,8 +173,8 @@ class GitHubCommand extends Command {
     }
 
     async getRepoInfo() {
-        const { TYPE, PATH } = this.bot.config.SOURCE,
-        data = {
+        const { TYPE, PATH } = this.bot.config.SOURCE;
+        const data = {
             // The website used's name
             sitename: null,
             // Date object for last push event
@@ -263,7 +265,7 @@ class GitHubCommand extends Command {
     async getCPUUsage() {
         let stats1 = this.getCPUInfo();
 
-        await this.wait(500);
+        await wait(500);
 
         let stats2 = this.getCPUInfo();
 

--- a/src/plugins/commander/commands/http.js
+++ b/src/plugins/commander/commands/http.js
@@ -20,20 +20,20 @@ class HTTPCommand extends Command {
         ];
     }
 
-    async call(message, content) {
+    call(message, content) {
         if (!content) return;
 
         const code = parseInt(content);
         if (isNaN(code)) return;
 
         if (this.validCodes.includes(code)) {
-            const attachment = new MessageAttachment(`https://http.cat/${code}.jpg`, `${code}.jpg`)
-
-            await message.channel.send(`<https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/${code}>`, attachment);
-            return;
+            return message.channel.send({
+                content: `<https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/${code}>`,
+                files: [new MessageAttachment(`https://http.cat/${code}.jpg`, `${code}.jpg`)]
+            });
         }
 
-        await message.channel.send(`https://http.cat/404.jpg`);
+        return message.channel.send(`https://http.cat/404.jpg`);
     }
 }
 

--- a/src/plugins/commander/commands/integration.js
+++ b/src/plugins/commander/commands/integration.js
@@ -13,7 +13,7 @@ class IntegrationCommand extends Command {
     }
 
     call(message) {
-        message.channel.send(`
+        return message.channel.send(`
 You can find the instructions for DiscordIntegrator installation here:
 ⟼ <https://dev.fandom.com/wiki/DiscordIntegrator/instructions>
 

--- a/src/plugins/commander/commands/javascript.js
+++ b/src/plugins/commander/commands/javascript.js
@@ -14,14 +14,14 @@ class JavaScriptCommand extends Command {
         ];
     }
 
-    call(message, content) {
+    async call(message, content) {
         if (content) return;
 
-        message.delete();
+        await message.delete();
         if (message.member.roles.cache.has('269869828691591169')) {
-            message.member.roles.remove('269869828691591169');
+            return message.member.roles.remove('269869828691591169');
         } else {
-            message.member.roles.add('269869828691591169');
+            return message.member.roles.add('269869828691591169');
         }
     }
 }

--- a/src/plugins/commander/commands/lua.js
+++ b/src/plugins/commander/commands/lua.js
@@ -14,14 +14,14 @@ class LuaRoleCommand extends Command {
         ];
     }
 
-    call(message, content) {
+    async call(message, content) {
         if (content) return;
 
-        message.delete();
+        await message.delete();
         if (message.member.roles.cache.has('269869890087682049')) {
-            message.member.roles.remove('269869890087682049');
+            return message.member.roles.remove('269869890087682049');
         } else {
-            message.member.roles.add('269869890087682049');
+            return message.member.roles.add('269869890087682049');
         }
     }
 }

--- a/src/plugins/commander/commands/member.js
+++ b/src/plugins/commander/commands/member.js
@@ -74,8 +74,8 @@ class MemberCommand extends Command {
             return message.channel.send(`The username and tag in the masthead do not match the username and tag of the message author. Use <https://dev.fandom.com/wiki/Special:VerifyUser/${encodeURIComponent(content)}?user=${encodeURIComponent(message.author.username)}&tag=${message.author.discriminator}&c=!member&ch=lobby> to remedy this.`);
         }
 
-        message.member.roles.add('246302564625285121');
-        message.channel.send('Role has been added.');
+        await message.member.roles.add('246302564625285121');
+        return message.channel.send('Role has been added.');
     }
 }
 

--- a/src/plugins/commander/commands/parse.js
+++ b/src/plugins/commander/commands/parse.js
@@ -63,7 +63,7 @@ class ParseCommand extends Command {
             }
         }
 
-        message.channel.send(this.bot.fmt.codeBlock('html', html));
+        return message.channel.send(this.bot.fmt.codeBlock('html', html));
     }
 }
 

--- a/src/plugins/commander/commands/personalcss.js
+++ b/src/plugins/commander/commands/personalcss.js
@@ -23,7 +23,7 @@ class PersonalCSSCommand extends Command {
         let wiki = content || 'dev',
         url = await this.bot.fandomizer.url(wiki);
 
-        message.channel.send(`
+        return message.channel.send(`
 Personal CSS pages are located on
 - <${url}/wiki/Special:Mypage/common.css>
 - <${url}/wiki/Special:Mypage/chat.css> (for chat)

--- a/src/plugins/commander/commands/personaljs.js
+++ b/src/plugins/commander/commands/personaljs.js
@@ -23,7 +23,7 @@ class PersonalJSCommand extends Command {
         let wiki = content || 'dev',
         url = await this.bot.fandomizer.url(wiki);
 
-        message.channel.send(`
+        return message.channel.send(`
 Personal JavaScript pages are located on
 - <${url}/wiki/Special:Mypage/common.js>
 - <${url}/wiki/Special:Mypage/chat.js> (for chat)

--- a/src/plugins/commander/commands/ping.js
+++ b/src/plugins/commander/commands/ping.js
@@ -20,7 +20,7 @@ class PingCommand extends Command {
 		const line = `:heartbeat: ${this.getPing()}ms`;
 		const reply = await message.channel.send(line);
 		const time = `:stopwatch: ${this.getSnowflakeTime(reply.id) - this.getSnowflakeTime(message.id)}ms`;
-		reply.edit(`${line}\n${time}`);
+		return reply.edit(`${line}\n${time}`);
 	}
 
 	getSnowflakeTime(id) {

--- a/src/plugins/commander/commands/portability.js
+++ b/src/plugins/commander/commands/portability.js
@@ -14,14 +14,14 @@ class PortabilityCommand extends Command {
         ];
     }
 
-    call(message, content) {
+    async call(message, content) {
         if (content) return;
 
-        message.delete();
+        await message.delete();
         if (message.member.roles.cache.has('311612168061714432')) {
-            message.member.roles.remove('311612168061714432');
+            return message.member.roles.remove('311612168061714432');
         } else {
-            message.member.roles.add('311612168061714432');
+            return message.member.roles.add('311612168061714432');
         }
     }
 }

--- a/src/plugins/commander/commands/quit.js
+++ b/src/plugins/commander/commands/quit.js
@@ -17,7 +17,7 @@ class QuitCommand extends OPCommand {
     async call(message) {
         await message.channel.send('Alright then');
 
-        this.bot.client.destroy();
+        this.bot.cleanup();
     }
 }
 

--- a/src/plugins/commander/commands/rc.js
+++ b/src/plugins/commander/commands/rc.js
@@ -26,7 +26,7 @@ class RCCommand extends Command {
             ? `<${await this.bot.fandomizer.url(content)}/wiki/Special:RecentChanges?feed=rss>`
             : this.bot.fmt.code('https://<yourwiki>.fandom.com/wiki/Special:RecentChanges?feed=rss');
 
-        message.channel.send(`
+        return message.channel.send(`
 The easiest way to set up a Recent Changes-to-Discord system is by inviting Wiki-Bot (<https://wikibot.fandom.com/wiki/Wiki-Bot_Wiki>) to your server and setting up its recent changes webhook.
 More information is available on the Wiki-Bot Wiki: <https://wikibot.fandom.com/wiki/Recent_changes_webhook>.
 

--- a/src/plugins/commander/commands/rules.js
+++ b/src/plugins/commander/commands/rules.js
@@ -15,7 +15,7 @@ class RulesCommand extends Command {
     }
 
     call(message) {
-        message.channel.send(`
+        return message.channel.send(`
 Rules of this server can be found in the <#246663167537709058> channel.
 Fandom Community Guidelines - <https://c.fandom.com/wiki/Community_Guidelines>
 Fandom Terms of Use - <https://fandom.com/terms-of-use>

--- a/src/plugins/commander/commands/runtime.js
+++ b/src/plugins/commander/commands/runtime.js
@@ -43,7 +43,7 @@ class RuntimeCommand extends Command {
     call(message) {
         const runtime = this.toDurationString(this.bot.client.uptime);
 
-        message.channel.send(`Bot has been up and running for ${runtime}!`);
+        return message.channel.send(`Bot has been up and running for ${runtime}!`);
     }
 }
 

--- a/src/plugins/commander/commands/scripts.js
+++ b/src/plugins/commander/commands/scripts.js
@@ -13,7 +13,7 @@ class ScriptsCommand extends Command {
     }
 
     call(message) {
-        message.channel.send(`You can find a list of JavaScript enhancements on <https://dev.fandom.com/wiki/List_of_JavaScript_enhancements>`);
+        return message.channel.send(`You can find a list of JavaScript enhancements on <https://dev.fandom.com/wiki/List_of_JavaScript_enhancements>`);
     }
 }
 

--- a/src/plugins/commander/commands/sitejs.js
+++ b/src/plugins/commander/commands/sitejs.js
@@ -20,10 +20,10 @@ class SiteJSCommand extends Command {
     }
 
     async call(message, content) {
-        let wiki = content || 'dev',
-        url = await this.bot.fandomizer.url(wiki);
+        const wiki = content || 'dev';
+        const url = await this.bot.fandomizer.url(wiki);
 
-        message.channel.send(`
+        return message.channel.send(`
 Wiki-wide JavaScript pages can be found on:
 - <${url}/wiki/MediaWiki:Common.js>
 - <${url}/wiki/MediaWiki:Chat.js> (for chat)

--- a/src/plugins/commander/commands/staff.js
+++ b/src/plugins/commander/commands/staff.js
@@ -10,7 +10,7 @@ class StaffCommand extends Command {
     }
 
     async call(message) {
-        message.channel.send(`You can contact FANDOM Staff through the contact form at <https://fandom.zendesk.com/hc/requests/new>.`);
+        return message.channel.send(`You can contact Fandom Staff through the contact form at <https://fandom.zendesk.com/hc/requests/new>.`);
     }
 }
 

--- a/src/plugins/commander/commands/test.js
+++ b/src/plugins/commander/commands/test.js
@@ -15,7 +15,7 @@ class TestCommand extends OPCommand {
     }
 
     call(message) {
-        message.channel.send('Tested!');
+        return message.channel.send('Tested!');
     }
 }
 

--- a/src/plugins/commander/commands/ucp.js
+++ b/src/plugins/commander/commands/ucp.js
@@ -11,10 +11,10 @@ class UCPCommand extends Command {
 
 	constructor(bot) {
 		super(bot);
-		this.aliases = ['ucp', 'compat'];
+		this.aliases = ['ucp', 'ucx', 'compat'];
 
-		this.shortdesc = `Posts links to UCP info.`;
-		this.desc = `Posts links to information about Fandom's UCP platform. You can optionally get info on a specified script/stylesheet's compatibility status by providing it as an argument.`;
+		this.shortdesc = `Posts links to UCP/UCX info.`;
+		this.desc = `Posts links to information about Fandom's Unified Comunity Platform/Unified Consumer Experience. You can optionally get info on a specified script/stylesheet's compatibility status by providing it as an argument.`;
 		this.usages = [
 			'!ucp [script/stylesheet]'
 		];
@@ -24,7 +24,7 @@ class UCPCommand extends Command {
 		];
 
 		this.linksString = `
-- Help - <https://c.fandom.com/Help:UCP>
+- Help - <https://c.fandom.com/Help:UCP>/<https://c.fandom.com/Help:FandomDesktop>
 - Information - <https://fandom.zendesk.com/hc/articles/360044776693>
 - Bugs, features, changes - <https://c.fandom.com/User:Noreplyz/UCP>
 - Content compatibility information - <https://dev.fandom.com/wiki/Dev_Wiki:UCP>`;
@@ -32,16 +32,14 @@ class UCPCommand extends Command {
 
 	async call(message, content) {
 		if (!content) {
-			await message.channel.send(this.linksString);
-			return;
+			return message.channel.send(this.linksString);
 		}
 
 		const pageContent = await got('https://dev.fandom.com/wiki/DEV:UCP?action=raw').text();
 		const line = pageContent.split('\n').find(line => line.slice(0, 7 + content.length) === `{{/row|${content}`);
 
 		if (line === undefined) {
-			await message.channel.send(this.linksString);
-			return;
+			return message.channel.send(this.linksString);
 		}
 
 		const [name, status, reason] = line.slice(7, -2).split('|');
@@ -51,7 +49,7 @@ class UCPCommand extends Command {
 			response.push(`${this.bot.fmt.bold('Reason')}: ${reason}`);
 		}
 
-		await message.channel.send(response.join('\n'));
+		return message.channel.send(response.join('\n'));
 	}
 }
 

--- a/src/plugins/commander/commands/wikitext.js
+++ b/src/plugins/commander/commands/wikitext.js
@@ -14,14 +14,14 @@ class WikitextRoleCommand extends Command {
         ];
     }
 
-    call(message, content) {
+    async call(message, content) {
         if (content) return;
 
-        message.delete();
+        await message.delete();
         if (message.member.roles.cache.has('269869867123867650')) {
-            message.member.roles.remove('269869867123867650');
+            return message.member.roles.remove('269869867123867650');
         } else {
-            message.member.roles.add('269869867123867650');
+            return message.member.roles.add('269869867123867650');
         }
     }
 }

--- a/src/plugins/commander/commands/xkcd.js
+++ b/src/plugins/commander/commands/xkcd.js
@@ -23,13 +23,11 @@ class XKCDCommand extends Command {
 
     async call(message, content) {
         if (!content) {
-            message.channel.send('https://xkcd.com/');
-            return;
+            return message.channel.send('https://xkcd.com/');
         }
 
         if (!Number.isNaN(parseInt(content))) {
-            message.channel.send(`https://xkcd.com/${content}`);
-            return;
+            return message.channel.send(`https://xkcd.com/${content}`);
         }
 
         const bawdy = await got.post('https://relevant-xkcd-backend.herokuapp.com/search', {
@@ -41,8 +39,8 @@ class XKCDCommand extends Command {
         if (bawdy.results.length === 0) return;
         const post = bawdy.results[0];
 
-        message.channel.send({
-            embed: {
+        return message.channel.send({
+            embeds: [{
                 title: post.title,
                 url: `https://xkcd.com/${post.number}`,
                 image: {
@@ -52,7 +50,7 @@ class XKCDCommand extends Command {
                     text: post.titletext
                 },
                 timestamp: new Date(post.date).toISOString()
-            }
+            }]
         });
     }
 }

--- a/src/plugins/commander/index.js
+++ b/src/plugins/commander/index.js
@@ -19,6 +19,10 @@ class CommanderPlugin extends Plugin {
     load() {
         this.bot.commander = new Commander(this.bot);
     }
+
+    cleanup() {
+        return this.bot.commander.cleanup();
+    }
 }
 
 class Commander {
@@ -109,7 +113,7 @@ class Commander {
                 const conflicting = priorityAliases[command.priority].includes(alias);
                 if (conflicting) {
                     this.log(`Duplicate alias: ${alias}`);
-                    this.log(`Conflicting commands: ${aliasMap[command.priority][alias]} & ${command}`);
+                    this.log(`Conflicting commands: ${aliasMap[command.priority][alias].constructor.name} & ${command.constructor.name}`);
                     return false;
                 }
 
@@ -219,11 +223,17 @@ class Commander {
             this.cleanStack = this.cleanStack || (await import('clean-stack')).default;
             const errorMessage = `${command.constructor.name}CallError: ${this.cleanStack(relevantLines.join('\n'))}`;
 
-            this.bot.logger.log('commander', errorMessage);
+            this.log(errorMessage);
 
             if (this.config.INLINE_ERRORS) {
                 await message.channel.send(this.bot.fmt.codeBlock('apache', errorMessage));
             }
+        }
+    }
+
+    async cleanup() {
+        for (const command of this.commands.values()) {
+            await command.cleanup();
         }
     }
 }

--- a/src/plugins/commander/index.js
+++ b/src/plugins/commander/index.js
@@ -37,7 +37,7 @@ class Commander {
 
         this.log = this.bot.logger.log.bind(this.bot.logger, 'commander');
 
-        bot.client.on('messageCreate', this.onMessage.bind(this));
+        bot.client.on('messageCreate', bot.wrapListener(this.onMessage, this));
     }
 
 
@@ -227,6 +227,8 @@ class Commander {
 
             if (this.config.INLINE_ERRORS) {
                 await message.channel.send(this.bot.fmt.codeBlock('apache', errorMessage));
+            } else {
+                await this.bot.reportError(`Error while executing ${command.constructor.name}:`, e);
             }
         }
     }

--- a/src/plugins/commander/structs/Command.js
+++ b/src/plugins/commander/structs/Command.js
@@ -28,6 +28,9 @@ class Command {
     call() {
         throw new Error('call() not implemented');
     }
+
+    cleanup() {
+    }
 }
 
 module.exports = Command;

--- a/src/plugins/commander/structs/Command.js
+++ b/src/plugins/commander/structs/Command.js
@@ -18,11 +18,7 @@ class Command {
     }
 
     isAdmin(message) {
-        return message.guild && message.member.hasPermission('ADMINISTRATOR');
-    }
-
-    wait(ms, val) {
-        return new Promise(res => setTimeout(res.bind(this, val), ms));
+        return message.guild && message.member.permissions.has('ADMINISTRATOR');
     }
 
     filter() {

--- a/src/plugins/db/transports/DropboxTransport.js
+++ b/src/plugins/db/transports/DropboxTransport.js
@@ -47,7 +47,7 @@ class DropboxTransport extends Transport {
             return def;
         }
 
-        const result = this.toJson(file.fileBinary.toString()) || def;
+        const result = this.toJson(String(file.result.fileBinary)) || def;
         this.cache.set(key, result);
 
         return result;

--- a/src/plugins/db/transports/DropboxTransport.js
+++ b/src/plugins/db/transports/DropboxTransport.js
@@ -1,6 +1,8 @@
 const Transport = require('./Transport.js');
 const { Dropbox } = require('dropbox');
 const fetch = require('node-fetch');
+const {promisify} = require('util');
+const wait = promisify(setTimeout);
 
 class DropboxTransport extends Transport {
     constructor(config) {
@@ -55,13 +57,13 @@ class DropboxTransport extends Transport {
 
     set(key, object) {
         this.cache.set(key, object);
-        this.queueSave(key, object);
+        return this.queueSave(key, object);
     }
 
-    async delete(key) {
+    delete(key) {
         this.query.delete(key);
         this.cache.delete(key);
-        await this.db.filesDelete({
+        return this.db.filesDelete({
             path: `/${key}`
         });
     }
@@ -76,7 +78,7 @@ class DropboxTransport extends Transport {
         this.saving = true;
 
         await Promise.all([
-            this.wait(this.delay),
+            wait(this.delay),
             this.write(key, this.cache.get(key))
         ]);
 
@@ -84,7 +86,7 @@ class DropboxTransport extends Transport {
         this.queue.shift();
 
         if (this.queue.length) {
-            this.queueSave();
+            return this.queueSave();
         }
     }
 
@@ -102,7 +104,7 @@ class DropboxTransport extends Transport {
         try {
             return JSON.parse(string);
         } catch(e) {
-            console.log(e);
+            console.error(e);
             return null;
         }
     }
@@ -112,10 +114,6 @@ class DropboxTransport extends Transport {
         const buffer = Buffer.from(stringified);
 
         return buffer.toString('base64');
-    }
-
-    wait(ms) {
-        return new Promise(res => setTimeout(res, ms));
     }
 }
 

--- a/src/plugins/db/transports/DropboxTransport.js
+++ b/src/plugins/db/transports/DropboxTransport.js
@@ -47,8 +47,6 @@ class DropboxTransport extends Transport {
             return def;
         }
 
-        console.log('got file', file);
-
         const result = this.toJson(file.fileBinary.toString()) || def;
         this.cache.set(key, result);
 

--- a/src/plugins/ipc/index.js
+++ b/src/plugins/ipc/index.js
@@ -20,8 +20,8 @@ class IPC {
         this.connections = {};
         this.connectionCount = 0;
         this.buffer = '';
-        bot.client.on('ready', this.onReady.bind(this));
-        bot.client.on('messageCreate', this.onMessage.bind(this));
+        bot.client.on('ready', bot.wrapListener(this.onReady, this));
+        bot.client.on('messageCreate', bot.wrapListener(this.onMessage, this));
     }
 
     async unlinkSocket() {
@@ -56,7 +56,7 @@ class IPC {
         this.connections[id] = socket;
         socket.on('end', () => delete this.connections[id]);
         socket.on('data', this.ipcMessage.bind(this, id));
-        socket.on('error', (e) => console.error(e));
+        socket.on('error', error => this.bot.reportError(error));
     }
 
     sendToSocket(socket, type, data) {

--- a/src/plugins/ipc/index.js
+++ b/src/plugins/ipc/index.js
@@ -8,8 +8,11 @@ class IPCPlugin extends Plugin {
             this.bot.ipc = new IPC(this.bot);
         }
     }
+
     cleanup() {
-        this.bot.ipc.cleanup();
+        if (this.bot.ipc) {
+            this.bot.ipc.cleanup();
+        }
     }
 }
 
@@ -94,6 +97,7 @@ class IPC {
         for (const id in this.connections) {
             this.connections[id].end();
         }
+
         this.server.close();
         return this.unlinkSocket();
     }

--- a/src/plugins/joinleave/index.js
+++ b/src/plugins/joinleave/index.js
@@ -15,9 +15,9 @@ class JoinLeave {
         this.specials = this.config.SPECIAL_JOIN_CODES || {};
         this.cache = new Map();
 
-        bot.client.on('ready', this.populateCache.bind(this));
-        bot.client.on('guildMemberAdd', this.onJoin.bind(this));
-        bot.client.on('guildMemberRemove', this.onLeave.bind(this));
+        bot.client.on('ready', bot.wrapListener(this.populateCache, this));
+        bot.client.on('guildMemberAdd', bot.wrapListener(this.onJoin, this));
+        bot.client.on('guildMemberRemove', bot.wrapListener(this.onLeave, this));
     }
 
     serialize(inviteCollection) {
@@ -42,9 +42,9 @@ class JoinLeave {
                 this.cache.set(guild.id, this.serialize(invites));
             } catch (error) {
                 if (error && error.code === 50013) {
-                    console.error('Missing permissions (MANAGE_SERVER) for fetching invites.');
+                    await this.bot.reportError('Missing permissions (MANAGE_SERVER) for fetching invites.');
                 } else {
-                    console.error('Error while populating cache:', error);
+                    await this.bot.reportError('Error while populating cache:', error);
                 }
             }
         }

--- a/src/plugins/joinleave/index.js
+++ b/src/plugins/joinleave/index.js
@@ -12,7 +12,7 @@ class JoinLeave {
         this.bot = bot;
         this.dev = bot.config.ENV === 'development';
         this.config = bot.config.JOIN_LEAVE;
-        this.specials = this.config.SPECIAL_JOIN_CODES;
+        this.specials = this.config.SPECIAL_JOIN_CODES || {};
         this.cache = new Map();
 
         bot.client.on('ready', this.populateCache.bind(this));
@@ -35,14 +35,19 @@ class JoinLeave {
         return object;
     }
 
-    populateCache() {
-        this.bot.client.guilds.cache.array().map(async guild => {
+    async populateCache() {
+        for (const [id, guild] of this.bot.client.guilds.cache.entries()) {
             try {
-                const invites = await guild.fetchInvites();
-
+                const invites = await guild.invites.fetch();
                 this.cache.set(guild.id, this.serialize(invites));
-            } catch(e) {}
-        });
+            } catch (error) {
+                if (error && error.code === 50013) {
+                    console.error('Missing permissions (MANAGE_SERVER) for fetching invites.');
+                } else {
+                    console.error('Error while populating cache:', error);
+                }
+            }
+        }
     }
 
     // Compares two invite collections and filters out the two who have changed
@@ -89,7 +94,7 @@ class JoinLeave {
         const cached = this.cache.get(guild.id);
         let current;
         try {
-            current = this.serialize(await guild.fetchInvites());
+            current = this.serialize(await guild.invites.fetch());
         } catch(e) {
             return null;
         }
@@ -149,7 +154,7 @@ class JoinLeave {
             message = this.specials[invite.code];
         }
 
-        channel.send(this.formatMessage(message, member));
+        return channel.send(this.formatMessage(message, member));
     }
 
     async onLeave(member) {
@@ -158,7 +163,7 @@ class JoinLeave {
         const channel = await this.getChannel(member.guild);
         if (!channel) return;
 
-        channel.send(this.formatMessage(this.config.LEAVE_MESSAGE, member));
+        return channel.send(this.formatMessage(this.config.LEAVE_MESSAGE, member));
     }
 }
 

--- a/src/plugins/joinleave/index.js
+++ b/src/plugins/joinleave/index.js
@@ -36,7 +36,7 @@ class JoinLeave {
     }
 
     async populateCache() {
-        for (const [id, guild] of this.bot.client.guilds.cache.entries()) {
+        for (const guild of this.bot.client.guilds.cache.values()) {
             try {
                 const invites = await guild.invites.fetch();
                 this.cache.set(guild.id, this.serialize(invites));

--- a/src/plugins/linker/index.js
+++ b/src/plugins/linker/index.js
@@ -31,8 +31,8 @@ class Linker {
         this.jar = new CookieJar();
         this.wikiVars = new Cache();
         if (this.config.USERNAME) {
-            this.login().catch(err => {
-                console.error('Linker login failure', err);
+            this.login().catch(async err => {
+                await this.bot.reportError('Linker login failure', err);
             });
         }
 
@@ -110,7 +110,7 @@ class Linker {
         //     }, 2));
         // });
 
-        bot.client.on('messageCreate', this.onMessage.bind(this));
+        bot.client.on('messageCreate', bot.wrapListener(this.onMessage, this));
     }
 
     hasStringKeys(arr) {

--- a/src/plugins/linker/index.js
+++ b/src/plugins/linker/index.js
@@ -32,8 +32,7 @@ class Linker {
         this.wikiVars = new Cache();
         if (this.config.USERNAME) {
             this.login().catch(err => {
-                console.error('Linker login failure');
-                console.error(err);
+                console.error('Linker login failure', err);
             });
         }
 
@@ -111,7 +110,7 @@ class Linker {
         //     }, 2));
         // });
 
-        bot.client.on('message', this.onMessage.bind(this));
+        bot.client.on('messageCreate', this.onMessage.bind(this));
     }
 
     hasStringKeys(arr) {
@@ -172,6 +171,7 @@ class Linker {
         const wiki = await this.getWiki(message.guild);
         const promises = this.getPromises(message, wiki);
         const results = await Promise.all(promises);
+        const returnedPromises = [];
 
         for (let result of results) {
             if (!result) continue;
@@ -182,23 +182,22 @@ class Linker {
 
             const reply = await message.channel.send(result);
 
-            Promise.all([
+            returnedPromises.push(Promise.all([
                 reply.react('❌'),
-                reply.awaitReactions(
-                    (reaction, reactor) => reactor.id === message.author.id && reaction.emoji.name === '❌',
-                    {
-                        time: 60000,
-                        max: 1
-                    }
-                ),
+                reply.awaitReactions({
+                    filter: (reaction, reactor) => reactor.id === message.author.id && reaction.emoji.name === '❌',
+                    time: 60000,
+                    max: 1
+                }),
             ]).then(([reaction, reactions]) => {
                 if (reactions.size) {
-                    reply.delete();
+                    return reply.delete();
                 } else {
-                    reaction.remove();
+                    return reaction.remove();
                 }
-            });
+            }));
         }
+        return Promise.all(returnedPromises);
     }
 
     login() {
@@ -296,7 +295,7 @@ class Linker {
         return text
             .replace(/<@!?[0-9]+>/g, input => {
                 const id = input.replace(/<|!|>|@/g, '');
-                if (message.channel.type === 'dm' || message.channel.type === 'group') {
+                if (message.channel.type === 'DM' || message.channel.type === 'GROUP_DM') {
                     return message.client.users.cache.has(id) ? `@${message.client.users.cache.get(id).username}` : input;
                 }
 
@@ -316,7 +315,7 @@ class Linker {
                     return input;
                 })
             .replace(/<@&[0-9]+>/g, input => {
-                if (message.channel.type === 'dm' || message.channel.type === 'group') return input;
+                if (message.channel.type === 'DM' || message.channel.type === 'GROUP_DM') return input;
                 const role = message.guild.roles.cache.get(input.replace(/<|@|>|&/g, ''));
                 if (role) return `@${role.name}`;
                 return input;
@@ -449,7 +448,7 @@ class Linker {
 
     getLinks(links, wiki, message) {
         // TODO: Implement 2000/2048 line splitting
-        const embeds = [];
+        const results = [];
 
         const shouldEmbed = links.some(match => match[2]);
         const hyperLinks = Promise.all(
@@ -457,13 +456,13 @@ class Linker {
                 .map(match => this.getLink(match, wiki, message))
         );
 
-        embeds.push(
+        results.push(
             hyperLinks.then(links => {
                 if (shouldEmbed) {
                     return {
-                        embed: {
+                        embeds: [{
                             description: links.join('\n')
-                        }
+                        }]
                     };
                 } else {
                     return links.join('\n');
@@ -471,7 +470,7 @@ class Linker {
             })
         );
 
-        return embeds;
+        return results;
     }
 
     async getLink(match, wiki, message) {
@@ -581,13 +580,12 @@ class Linker {
 
     // API helper
     async api(wiki, params) {
-        params.format = 'json';
-
-        const body = await got(`${await this.wikiUrl(wiki)}/api.php`, {
-            searchParams: params,
+        return await got(`${await this.wikiUrl(wiki)}/api.php`, {
+            searchParams: {
+                format: 'json',
+                ...params
+            },
         }).json();
-
-        return body;
     }
 
     async fetchArticleProps(title, wiki) {
@@ -744,7 +742,7 @@ class Linker {
         const embed = await this.buildArticleEmbed(props, data, wiki, message);
 
         return {
-            embed
+            embeds: [embed]
         };
     }
 
@@ -992,7 +990,7 @@ class Linker {
         }
 
         return {
-            embed: {
+            embeds: [{
                 title: cur.title,
                 url: `${url}/?diff=${curid}&oldid=${oldid}`,
                 color: message.guild.me.displayColor,
@@ -1004,7 +1002,7 @@ class Linker {
                         ? `${cur.comment} - ${cur.user}`
                         : `Edited by ${cur.user}`
                 }
-            }
+            }]
         }
     }
 

--- a/src/plugins/logger/index.js
+++ b/src/plugins/logger/index.js
@@ -30,14 +30,14 @@ class Logger {
 
         fs.mkdir(this.logPath, () => {});
 
-        bot.client.on('message', this.onMessage.bind(this));
+        bot.client.on('messageCreate', this.onMessage.bind(this));
     }
 
     onMessage(message) {
 		// if (message.author.bot && message.author.id !== this.bot.client.user.id) return;
 		if (this.config.CHANNEL && message.channel.id === this.config.CHANNEL) return;
 
-        const place = message.channel.type === 'dm'
+        const place = message.channel.type === 'DM'
             ? 'DMs'
             : `${message.guild.name}#${message.channel.name}`;
 
@@ -72,7 +72,7 @@ class Logger {
         const general = this.writers.get('main', () => fs.createWriteStream(path.join(this.logPath, 'main.txt'), { flags: 'a' }));
         // const channel = this.writers.get(label, () => fs.createWriteStream(path.join(this.logPath, `${label}.txt`), { flags: 'a' }));
 
-        console.log(logEntry);
+        console.info(logEntry);
         general.write(logEntry + '\n');
 
         if (this.config.CHANNEL) {
@@ -122,15 +122,8 @@ class Logger {
     }
 
     getLog(name) {
-        return new Promise((res, rej) => {
-            fs.readFile(path.join(this.logPath, `${name}.txt`), (err, data) => {
-                if (err) {
-                    rej(err);
-                    return;
-                }
-
-                res(data.toString());
-            });
+        return fs.promises.readFile(path.join(this.logPath, `${name}.txt`), {
+            encoding: 'utf-8'
         });
     }
 
@@ -225,13 +218,13 @@ class Logger {
     }
 
     formatTime(timestamp) {
-        const d = new Date(timestamp),
-        date = this.pad(d.getUTCDate()),
-        month = this.pad(d.getUTCMonth() + 1),
-        year = this.pad(d.getUTCFullYear()),
-        hour = this.pad(d.getUTCHours()),
-        mins = this.pad(d.getUTCMinutes()),
-        secs = this.pad(d.getUTCSeconds());
+        const d = new Date(timestamp);
+        const date = this.pad(d.getUTCDate());
+        const month = this.pad(d.getUTCMonth() + 1);
+        const year = this.pad(d.getUTCFullYear());
+        const hour = this.pad(d.getUTCHours());
+        const mins = this.pad(d.getUTCMinutes());
+        const secs = this.pad(d.getUTCSeconds());
 
         return `${date}/${month}/${year} ${hour}:${mins}:${secs}`;
     }

--- a/src/plugins/logger/index.js
+++ b/src/plugins/logger/index.js
@@ -30,7 +30,7 @@ class Logger {
 
         fs.mkdir(this.logPath, () => {});
 
-        bot.client.on('messageCreate', this.onMessage.bind(this));
+        bot.client.on('messageCreate', bot.wrapListener(this.onMessage, this));
     }
 
     onMessage(message) {

--- a/src/plugins/preload/index.js
+++ b/src/plugins/preload/index.js
@@ -11,7 +11,7 @@ class Preload {
 		this.bot = bot;
 		this.config = bot.config.PRELOAD;
 
-		bot.client.on('ready', this.onReady.bind(this));
+		bot.client.on('ready', bot.wrapListener(this.onReady, this));
 	}
 
 	async onReady() {
@@ -25,7 +25,7 @@ class Preload {
 		try {
 			await guild.members.fetch();
 		} catch (error) {
-			console.error('Failed to preload guild', guildId, 'have you enabled the guild members intent?', error);
+			await this.bot.reportError(`Failed to preload guild ${guildId} have you enabled the guild members intent?`, error);
 		}
 	}
 }

--- a/src/plugins/preload/index.js
+++ b/src/plugins/preload/index.js
@@ -14,8 +14,8 @@ class Preload {
 		bot.client.on('ready', this.onReady.bind(this));
 	}
 
-	onReady() {
-		this.config.GUILDS.forEach(this.preloadUsers.bind(this));
+	async onReady() {
+		await Promise.all(this.config.GUILDS.map(this.preloadUsers.bind(this)));
 	}
 
 	async preloadUsers(guildId) {

--- a/src/plugins/quoter/index.js
+++ b/src/plugins/quoter/index.js
@@ -19,7 +19,7 @@ class Quoter {
         this.dev = bot.config.ENV === 'development';
         this.config = bot.config.QUOTER;
         this.QUOTE_PATTERN = /(?<!<)https?:\/\/(?:(?:canary|ptb)\.)?discord(?:app)?\.com\/channels\/(@me|\d+)\/(\d+)\/(\d+)(?!>)/g;
-        bot.client.on('message', this.onMessage.bind(this));
+        bot.client.on('messageCreate', this.onMessage.bind(this));
     }
 
     matchQuotes(text) {
@@ -72,16 +72,12 @@ class Quoter {
             && quotes.length <= this.config.MAX
             && message.content.replace(this.QUOTE_PATTERN, '').trim() === '';
 
-        for (const i in filtered) {
-            const quote = filtered[i],
-            embed = this.buildQuoteEmbed(message, quote, i === '0'); // Go figure, array indices when for..in are strings!
-
-            if (!embed) continue;
-
-            await message.channel.send({
-                embed
-            });
-        }
+        const embeds = filtered
+            .map((quote, i) => this.buildQuoteEmbed(message, quote, i === 0))
+            .filter(Boolean)
+        await message.channel.send({
+            embeds
+        });
 
         if (shouldDelete) {
             try {
@@ -93,7 +89,7 @@ class Quoter {
     }
 
     async tryFetchQuote([_, guildId, channelId, messageId]) {
-        if (guildId == '@me') return null;
+        if (guildId === '@me') return null;
 
         try {
             const channel = await this.bot.client.channels.fetch(channelId);
@@ -124,7 +120,7 @@ class Quoter {
             }
         }
 
-        let description = this.bot.fmt.bold(this.bot.fmt.link('Click to jump', `https://discordapp.com/channels/${quote.guild.id}/${quote.channel.id}/${quote.id}`));
+        let description = this.bot.fmt.bold(this.bot.fmt.link('Click to jump', `https://discord.com/channels/${quote.guild.id}/${quote.channel.id}/${quote.id}`));
 
         if (quote.content) {
             description += '\n\n' + quote.content;
@@ -148,7 +144,7 @@ class Quoter {
         return {
             author,
             // title: 'Click to jump',
-            // url: `https://discordapp.com/channels/${quote.guild.id}/${quote.channel.id}/${quote.id}`,
+            // url: `https://discord.com/channels/${quote.guild.id}/${quote.channel.id}/${quote.id}`,
             description,
             image: image || undefined,
             footer: {
@@ -217,13 +213,13 @@ class Quoter {
     }
 
     formatTime(timestamp) {
-        const d = new Date(timestamp),
-        date = this.pad(d.getUTCDate()),
-        month = this.pad(d.getUTCMonth() + 1),
-        year = this.pad(d.getUTCFullYear()),
-        hour = this.pad(d.getUTCHours()),
-        mins = this.pad(d.getUTCMinutes()),
-        secs = this.pad(d.getUTCSeconds());
+        const d = new Date(timestamp);
+        const date = this.pad(d.getUTCDate());
+        const month = this.pad(d.getUTCMonth() + 1);
+        const year = this.pad(d.getUTCFullYear());
+        const hour = this.pad(d.getUTCHours());
+        const mins = this.pad(d.getUTCMinutes());
+        const secs = this.pad(d.getUTCSeconds());
 
         return `${date}/${month}/${year} ${hour}:${mins}:${secs}`;
     }

--- a/src/plugins/quoter/index.js
+++ b/src/plugins/quoter/index.js
@@ -19,7 +19,7 @@ class Quoter {
         this.dev = bot.config.ENV === 'development';
         this.config = bot.config.QUOTER;
         this.QUOTE_PATTERN = /(?<!<)https?:\/\/(?:(?:canary|ptb)\.)?discord(?:app)?\.com\/channels\/(@me|\d+)\/(\d+)\/(\d+)(?!>)/g;
-        bot.client.on('messageCreate', this.onMessage.bind(this));
+        bot.client.on('messageCreate', bot.wrapListener(this.onMessage, this));
     }
 
     matchQuotes(text) {

--- a/src/plugins/restartnotify/index.js
+++ b/src/plugins/restartnotify/index.js
@@ -32,13 +32,13 @@ class RestartNotify {
         } else {
             channelId = await this.bot.db.get('lastRestartChannel');
             if (!channelId) return;
-            this.bot.db.delete('lastRestartChannel');
+            await this.bot.db.delete('lastRestartChannel');
         }
 
         const channel = await this.bot.client.channels.fetch(channelId);
         if (!channel) return;
 
-        channel.send('Restarted!');
+        return channel.send('Restarted!');
     }
 }
 

--- a/src/plugins/restartnotify/index.js
+++ b/src/plugins/restartnotify/index.js
@@ -22,7 +22,7 @@ class RestartNotifyPlugin extends Plugin {
 class RestartNotify {
     constructor(bot) {
         this.bot = bot;
-        bot.client.on('ready', this.onReady.bind(this));
+        bot.client.on('ready', bot.wrapListener(this.onReady, this));
     }
 
     async onReady() {

--- a/src/structs/Plugin.js
+++ b/src/structs/Plugin.js
@@ -12,6 +12,9 @@ class Plugin {
     load() {
         throw new Error('load() not implemented');
     }
+
+    cleanup() {
+    }
 }
 
 module.exports = Plugin;

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,35 +2,51 @@
 # yarn lockfile v1
 
 
-"@discordjs/collection@^0.1.6":
-  version "0.1.6"
-  resolved "https://registry.yarnpkg.com/@discordjs/collection/-/collection-0.1.6.tgz#9e9a7637f4e4e0688fd8b2b5c63133c91607682c"
-  integrity sha512-utRNxnd9kSS2qhyivo9lMlt5qgAUasH2gb7BEOn6p0efFh24gjGomHzWKMAPn2hEReOPQZCJaRKoURwRotKucQ==
+"@discordjs/builders@^0.4.0":
+  version "0.4.0"
+  resolved "https://registry.npmjs.org/@discordjs/builders/-/builders-0.4.0.tgz"
+  integrity sha512-EiwLltKph6TSaPJIzJYdzNc1PnA2ZNaaE0t0ODg3ghnpVHqfgd0YX9/srsleYHW2cw1sfIq+kbM+h0etf7GWLA==
+  dependencies:
+    "@sindresorhus/is" "^4.0.1"
+    discord-api-types "^0.22.0"
+    ow "^0.27.0"
+    ts-mixer "^6.0.0"
+    tslib "^2.3.0"
+
+"@discordjs/collection@^0.2.1":
+  version "0.2.1"
+  resolved "https://registry.npmjs.org/@discordjs/collection/-/collection-0.2.1.tgz"
+  integrity sha512-vhxqzzM8gkomw0TYRF3tgx7SwElzUlXT/Aa41O7mOcyN6wIJfj5JmDWaO5XGKsGSsNx7F3i5oIlrucCCWV1Nog==
 
 "@discordjs/form-data@^3.0.1":
   version "3.0.1"
-  resolved "https://registry.yarnpkg.com/@discordjs/form-data/-/form-data-3.0.1.tgz#5c9e6be992e2e57d0dfa0e39979a850225fb4697"
+  resolved "https://registry.npmjs.org/@discordjs/form-data/-/form-data-3.0.1.tgz"
   integrity sha512-ZfFsbgEXW71Rw/6EtBdrP5VxBJy4dthyC0tpQKGKmYFImlmmrykO14Za+BiIVduwjte0jXEBlhSKf0MWbFp9Eg==
   dependencies:
     asynckit "^0.4.0"
     combined-stream "^1.0.8"
     mime-types "^2.1.12"
 
-"@sindresorhus/is@^1.0.0":
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/@sindresorhus/is/-/is-1.2.0.tgz#63ce3638cb85231f3704164c90a18ef816da3fb7"
-  integrity sha512-mwhXGkRV5dlvQc4EgPDxDxO6WuMBVymGFd1CA+2Y+z5dG9MNspoQ+AWjl/Ld1MnpCL8AKbosZlDVohqcIwuWsw==
+"@sapphire/async-queue@^1.1.4":
+  version "1.1.4"
+  resolved "https://registry.npmjs.org/@sapphire/async-queue/-/async-queue-1.1.4.tgz"
+  integrity sha512-fFrlF/uWpGOX5djw5Mu2Hnnrunao75WGey0sP0J3jnhmrJ5TAPzHYOmytD5iN/+pMxS+f+u/gezqHa9tPhRHEA==
 
-"@szmarczak/http-timer@^4.0.0":
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/@szmarczak/http-timer/-/http-timer-4.0.0.tgz#309789ccb7842ff1e41848cf43da587f78068836"
-  integrity sha512-3yoXv8OtGr/r3R5gaWWNQ3VUoQ5G3Gmo8DXX95V14ZVvE2b7Pj6Ide9uIDON8ym4D/ItyfL9ejohYUPqOyvRXw==
+"@sindresorhus/is@^4.0.0", "@sindresorhus/is@^4.0.1":
+  version "4.0.1"
+  resolved "https://registry.npmjs.org/@sindresorhus/is/-/is-4.0.1.tgz"
+  integrity sha512-Qm9hBEBu18wt1PO2flE7LPb30BHMQt1eQgbV76YntdNk73XZGpn3izvGTYxbGgzXKgbCjiia0uxTd3aTNQrY/g==
+
+"@szmarczak/http-timer@^4.0.5":
+  version "4.0.6"
+  resolved "https://registry.npmjs.org/@szmarczak/http-timer/-/http-timer-4.0.6.tgz"
+  integrity sha512-4BAffykYOgO+5nzBWYwE3W90sBgLJoUPRWWcL8wlyiM8IB8ipJz3UMJ9KXQd1RKQXpKp8Tutn80HZtWsu2u76w==
   dependencies:
-    defer-to-connect "^1.1.1"
+    defer-to-connect "^2.0.0"
 
 "@types/cacheable-request@^6.0.1":
   version "6.0.1"
-  resolved "https://registry.yarnpkg.com/@types/cacheable-request/-/cacheable-request-6.0.1.tgz#5d22f3dded1fd3a84c0bbeb5039a7419c2c91976"
+  resolved "https://registry.npmjs.org/@types/cacheable-request/-/cacheable-request-6.0.1.tgz"
   integrity sha512-ykFq2zmBGOCbpIXtoVbz4SKY5QriWPh3AjyU4G74RYbtt5yOc5OfaY75ftjg7mikMOla1CTGpX3lLbuJh8DTrQ==
   dependencies:
     "@types/http-cache-semantics" "*"
@@ -40,81 +56,66 @@
 
 "@types/http-cache-semantics@*":
   version "4.0.0"
-  resolved "https://registry.yarnpkg.com/@types/http-cache-semantics/-/http-cache-semantics-4.0.0.tgz#9140779736aa2655635ee756e2467d787cfe8a2a"
+  resolved "https://registry.npmjs.org/@types/http-cache-semantics/-/http-cache-semantics-4.0.0.tgz"
   integrity sha512-c3Xy026kOF7QOTn00hbIllV1dLR9hG9NkSrLQgCVs8NF6sBU+VGWjD3wLPhmh1TYAc7ugCFsvHYMN4VcBN1U1A==
 
 "@types/keyv@*":
   version "3.1.1"
-  resolved "https://registry.yarnpkg.com/@types/keyv/-/keyv-3.1.1.tgz#e45a45324fca9dab716ab1230ee249c9fb52cfa7"
+  resolved "https://registry.npmjs.org/@types/keyv/-/keyv-3.1.1.tgz"
   integrity sha512-MPtoySlAZQ37VoLaPcTHCu1RWJ4llDkULYZIzOYxlhxBqYPB0RsRlmMU0R6tahtFe27mIdkHV+551ZWV4PLmVw==
   dependencies:
     "@types/node" "*"
 
 "@types/node@*":
   version "13.5.0"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-13.5.0.tgz#4e498dbf355795a611a87ae5ef811a8660d42662"
+  resolved "https://registry.npmjs.org/@types/node/-/node-13.5.0.tgz"
   integrity sha512-Onhn+z72D2O2Pb2ql2xukJ55rglumsVo1H6Fmyi8mlU9SvKdBk/pUSUAiBY/d9bAOF7VVWajX3sths/+g6ZiAQ==
 
-"@types/responselike@*":
+"@types/responselike@*", "@types/responselike@^1.0.0":
   version "1.0.0"
-  resolved "https://registry.yarnpkg.com/@types/responselike/-/responselike-1.0.0.tgz#251f4fe7d154d2bad125abe1b429b23afd262e29"
+  resolved "https://registry.npmjs.org/@types/responselike/-/responselike-1.0.0.tgz"
   integrity sha512-85Y2BjiufFzaMIlvJDvTTB8Fxl2xfLo4HgmHzVBz08w4wDePCTjYw66PdrolO0kzli3yam/YCgRufyo1DdQVTA==
   dependencies:
     "@types/node" "*"
 
-abort-controller@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/abort-controller/-/abort-controller-3.0.0.tgz#eaf54d53b62bae4138e809ca225c8439a6efb392"
-  integrity sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==
+"@types/ws@^7.4.7":
+  version "7.4.7"
+  resolved "https://registry.npmjs.org/@types/ws/-/ws-7.4.7.tgz"
+  integrity sha512-JQbbmxZTZehdc2iszGKs5oC3NFnjeay7mtAWrdt7qNtAVK0g19muApzAy4bm9byz79xa2ZnO/BOBC2R8RC5Lww==
   dependencies:
-    event-target-shim "^5.0.0"
+    "@types/node" "*"
 
 asynckit@^0.4.0:
   version "0.4.0"
-  resolved "https://registry.yarnpkg.com/asynckit/-/asynckit-0.4.0.tgz#c79ed97f7f34cb8f2ba1bc9790bcc366474b4b79"
+  resolved "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz"
   integrity sha1-x57Zf380y48robyXkLzDZkdLS3k=
 
 balanced-match@^1.0.0:
   version "1.0.0"
-  resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-1.0.0.tgz#89b4d199ab2bee49de164ea02b89ce462d71b767"
+  resolved "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz"
   integrity sha1-ibTRmasr7kneFk6gK4nORi1xt2c=
-
-base64-js@^1.0.2:
-  version "1.3.1"
-  resolved "https://registry.yarnpkg.com/base64-js/-/base64-js-1.3.1.tgz#58ece8cb75dd07e71ed08c736abc5fac4dbf8df1"
-  integrity sha512-mLQ4i2QO1ytvGWFWmcngKO//JXAQueZvwEKtjgQFM4jIK0kU+ytMfplL8j+n5mspOfjHwoAg+9yhb7BwAHm36g==
 
 boolbase@^1.0.0:
   version "1.0.0"
-  resolved "https://registry.yarnpkg.com/boolbase/-/boolbase-1.0.0.tgz#68dff5fbe60c51eb37725ea9e3ed310dcc1e776e"
+  resolved "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz"
   integrity sha1-aN/1++YMUes3cl6p4+0xDcwed24=
 
 brace-expansion@^1.1.7:
   version "1.1.11"
-  resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-1.1.11.tgz#3c7fcbf529d87226f3d2f52b966ff5271eb441dd"
+  resolved "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz"
   integrity sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==
   dependencies:
     balanced-match "^1.0.0"
     concat-map "0.0.1"
 
-buffer@^5.0.8:
-  version "5.4.3"
-  resolved "https://registry.yarnpkg.com/buffer/-/buffer-5.4.3.tgz#3fbc9c69eb713d323e3fc1a895eee0710c072115"
-  integrity sha512-zvj65TkFeIt3i6aj5bIvJDzjjQQGs4o/sNoezg1F1kYap9Nu2jcUdpwzRSJTHMMzG0H7bZkn4rNQpImhuxWX2A==
-  dependencies:
-    base64-js "^1.0.2"
-    ieee754 "^1.1.4"
-
-cacheable-lookup@^0.2.1:
-  version "0.2.2"
-  resolved "https://registry.yarnpkg.com/cacheable-lookup/-/cacheable-lookup-0.2.2.tgz#5db9a480af3c55494e0a8e57c3c5095c3d314dd3"
-  integrity sha512-+XR+sYSw3gWyyL/4em004eP3RzisWDaGnBPbGpXl4GFSJSiliomxBU9AvStC6W9ivFuDbEcHwuWCEoSqBrK8Ww==
-  dependencies:
-    keyv "^4.0.0"
+cacheable-lookup@^5.0.3:
+  version "5.0.4"
+  resolved "https://registry.npmjs.org/cacheable-lookup/-/cacheable-lookup-5.0.4.tgz"
+  integrity sha512-2/kNscPhpcxrOigMZzbiWF7dz8ilhb/nIHU3EyZiXWXpeq/au8qJ8VhdftMkty3n7Gj6HIGalQG8oiBNB3AJgA==
 
 cacheable-request@^7.0.1:
   version "7.0.1"
-  resolved "https://registry.yarnpkg.com/cacheable-request/-/cacheable-request-7.0.1.tgz#062031c2856232782ed694a257fa35da93942a58"
+  resolved "https://registry.npmjs.org/cacheable-request/-/cacheable-request-7.0.1.tgz"
   integrity sha512-lt0mJ6YAnsrBErpTMWeu5kl/tg9xMAWjavYTN6VQXM1A/teBITuNcccXsCxF0tDQQJf9DfAaX5O4e0zp0KlfZw==
   dependencies:
     clone-response "^1.0.2"
@@ -125,90 +126,102 @@ cacheable-request@^7.0.1:
     normalize-url "^4.1.0"
     responselike "^2.0.0"
 
-clean-stack@2.2.0:
-  version "2.2.0"
-  resolved "https://registry.yarnpkg.com/clean-stack/-/clean-stack-2.2.0.tgz#ee8472dbb129e727b31e8a10a427dee9dfe4008b"
-  integrity sha512-4diC9HaTE+KRAMWhDhrGOECgWZxoevMc5TlkObMqNSsVU62PYzXZ/SMTjzyGAFF1YusgxGcSWTEXBhp0CPwQ1A==
+callsites@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz"
+  integrity sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==
+
+clean-stack@^4.1.0:
+  version "4.1.0"
+  resolved "https://registry.npmjs.org/clean-stack/-/clean-stack-4.1.0.tgz"
+  integrity sha512-dxXQYI7mfQVcaF12s6sjNFoZ6ZPDQuBBLp3QJ5156k9EvUFClUoZ11fo8HnLQO241DDVntHEug8MOuFO5PSfRg==
+  dependencies:
+    escape-string-regexp "5.0.0"
 
 clone-response@^1.0.2:
   version "1.0.2"
-  resolved "https://registry.yarnpkg.com/clone-response/-/clone-response-1.0.2.tgz#d1dc973920314df67fbeb94223b4ee350239e96b"
+  resolved "https://registry.npmjs.org/clone-response/-/clone-response-1.0.2.tgz"
   integrity sha1-0dyXOSAxTfZ/vrlCI7TuNQI56Ws=
   dependencies:
     mimic-response "^1.0.0"
 
 combined-stream@^1.0.8:
   version "1.0.8"
-  resolved "https://registry.yarnpkg.com/combined-stream/-/combined-stream-1.0.8.tgz#c3d45a8b34fd730631a110a8a2520682b31d5a7f"
+  resolved "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz"
   integrity sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==
   dependencies:
     delayed-stream "~1.0.0"
 
 concat-map@0.0.1:
   version "0.0.1"
-  resolved "https://registry.yarnpkg.com/concat-map/-/concat-map-0.0.1.tgz#d8a96bd77fd68df7793a73036a3ba0d5405d477b"
+  resolved "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
   integrity sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=
 
 confusables@^1.0.0:
   version "1.0.0"
-  resolved "https://registry.yarnpkg.com/confusables/-/confusables-1.0.0.tgz#b962cad8a6b49bd22c31423a581f2f6a68ad4ac6"
+  resolved "https://registry.npmjs.org/confusables/-/confusables-1.0.0.tgz"
   integrity sha512-HdrRONFehJdy173Heqosrsy5JLwUjH5A2/Q1xHHmDTp089YWgkSmU7aiRCprqHSz/Le5fThaOnU9WSj70BUvAw==
 
-css-select@^3.1.2:
-  version "3.1.2"
-  resolved "https://registry.yarnpkg.com/css-select/-/css-select-3.1.2.tgz#d52cbdc6fee379fba97fb0d3925abbd18af2d9d8"
-  integrity sha512-qmss1EihSuBNWNNhHjxzxSfJoFBM/lERB/Q4EnsJQQC62R2evJDW481091oAdOr9uh46/0n4nrg0It5cAnj1RA==
+css-select@^4.1.3:
+  version "4.1.3"
+  resolved "https://registry.npmjs.org/css-select/-/css-select-4.1.3.tgz"
+  integrity sha512-gT3wBNd9Nj49rAbmtFHj1cljIAOLYSX1nZ8CB7TBO3INYckygm5B7LISU/szY//YmdiSLbJvDLOx9VnMVpMBxA==
   dependencies:
     boolbase "^1.0.0"
-    css-what "^4.0.0"
-    domhandler "^4.0.0"
-    domutils "^2.4.3"
+    css-what "^5.0.0"
+    domhandler "^4.2.0"
+    domutils "^2.6.0"
     nth-check "^2.0.0"
 
-css-what@^4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/css-what/-/css-what-4.0.0.tgz#35e73761cab2eeb3d3661126b23d7aa0e8432233"
-  integrity sha512-teijzG7kwYfNVsUh2H/YN62xW3KK9YhXEgSlbxMlcyjPNvdKJqFx5lrwlJgoFP1ZHlB89iGDlo/JyshKeRhv5A==
+css-what@^5.0.0:
+  version "5.0.1"
+  resolved "https://registry.npmjs.org/css-what/-/css-what-5.0.1.tgz"
+  integrity sha512-FYDTSHb/7KXsWICVsxdmiExPjCfRC4qRFBdVwv7Ax9hMnvMmEjP9RfxTEZ3qPZGmADDn2vAKSo9UcN1jKVYscg==
 
-decompress-response@^5.0.0:
-  version "5.0.0"
-  resolved "https://registry.yarnpkg.com/decompress-response/-/decompress-response-5.0.0.tgz#7849396e80e3d1eba8cb2f75ef4930f76461cb0f"
-  integrity sha512-TLZWWybuxWgoW7Lykv+gq9xvzOsUjQ9tF09Tj6NSTYGMTCHNXzrPnD6Hi+TgZq19PyTAGH4Ll/NIM/eTGglnMw==
+decompress-response@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.npmjs.org/decompress-response/-/decompress-response-6.0.0.tgz"
+  integrity sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==
   dependencies:
-    mimic-response "^2.0.0"
+    mimic-response "^3.1.0"
 
-defer-to-connect@^1.1.1:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/defer-to-connect/-/defer-to-connect-1.1.1.tgz#88ae694b93f67b81815a2c8c769aef6574ac8f2f"
-  integrity sha512-J7thop4u3mRTkYRQ+Vpfwy2G5Ehoy82I14+14W4YMDLKdWloI9gSzRbV30s/NckQGVJtPkWNcW4oMAUigTdqiQ==
+defer-to-connect@^2.0.0:
+  version "2.0.1"
+  resolved "https://registry.npmjs.org/defer-to-connect/-/defer-to-connect-2.0.1.tgz"
+  integrity sha512-4tvttepXG1VaYGrRibk5EwJd1t4udunSOVMdLSAL6mId1ix438oPwPZMALY41FCijukO1L0twNcGsdzS7dHgDg==
 
 delayed-stream@~1.0.0:
   version "1.0.0"
-  resolved "https://registry.yarnpkg.com/delayed-stream/-/delayed-stream-1.0.0.tgz#df3ae199acadfb7d440aaae0b29e2272b24ec619"
+  resolved "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz"
   integrity sha1-3zrhmayt+31ECqrgsp4icrJOxhk=
 
-diff@^4.0.2:
-  version "4.0.2"
-  resolved "https://registry.yarnpkg.com/diff/-/diff-4.0.2.tgz#60f3aecb89d5fae520c11aa19efc2bb982aade7d"
-  integrity sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==
+diff@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.npmjs.org/diff/-/diff-5.0.0.tgz"
+  integrity sha512-/VTCrvm5Z0JGty/BWHljh+BAiw3IK+2j87NGMu8Nwc/f48WoDAC395uomO9ZD117ZOBaHmkX1oyLvkVM/aIT3w==
 
-discord.js@^12.3.1:
-  version "12.3.1"
-  resolved "https://registry.yarnpkg.com/discord.js/-/discord.js-12.3.1.tgz#8f58ac17d29b068dbfeb6c01fc7777bacd5324cf"
-  integrity sha512-mSFyV/mbvzH12UXdS4zadmeUf8IMQOo/YdunubG1wWt1xjWvtaJz/s9CGsFD2B5pTw1W/LXxxUbrQjIZ/xlUdw==
+discord-api-types@^0.22.0:
+  version "0.22.0"
+  resolved "https://registry.npmjs.org/discord-api-types/-/discord-api-types-0.22.0.tgz"
+  integrity sha512-l8yD/2zRbZItUQpy7ZxBJwaLX/Bs2TGaCthRppk8Sw24LOIWg12t9JEreezPoYD0SQcC2htNNo27kYEpYW/Srg==
+
+discord.js@^13.0.1:
+  version "13.0.1"
+  resolved "https://registry.npmjs.org/discord.js/-/discord.js-13.0.1.tgz"
+  integrity sha512-pEODCFfxypBnGEYpSgjkn1jt70raCS1um7Zp0AXEfW1DcR29wISzQ/WeWdnjP5KTXGi0LTtkRiUjOsMgSoukxA==
   dependencies:
-    "@discordjs/collection" "^0.1.6"
+    "@discordjs/builders" "^0.4.0"
+    "@discordjs/collection" "^0.2.1"
     "@discordjs/form-data" "^3.0.1"
-    abort-controller "^3.0.0"
-    node-fetch "^2.6.0"
-    prism-media "^1.2.2"
-    setimmediate "^1.0.5"
-    tweetnacl "^1.0.3"
-    ws "^7.3.1"
+    "@sapphire/async-queue" "^1.1.4"
+    "@types/ws" "^7.4.7"
+    discord-api-types "^0.22.0"
+    node-fetch "^2.6.1"
+    ws "^7.5.1"
 
 dom-serializer@^1.0.1:
   version "1.3.1"
-  resolved "https://registry.yarnpkg.com/dom-serializer/-/dom-serializer-1.3.1.tgz#d845a1565d7c041a95e5dab62184ab41e3a519be"
+  resolved "https://registry.npmjs.org/dom-serializer/-/dom-serializer-1.3.1.tgz"
   integrity sha512-Pv2ZluG5ife96udGgEDovOOOA5UELkltfJpnIExPrAk1LTvecolUGn6lIaoLh86d83GiB86CjzciMd9BuRB71Q==
   dependencies:
     domelementtype "^2.0.1"
@@ -217,203 +230,211 @@ dom-serializer@^1.0.1:
 
 domelementtype@^2.0.1, domelementtype@^2.2.0:
   version "2.2.0"
-  resolved "https://registry.yarnpkg.com/domelementtype/-/domelementtype-2.2.0.tgz#9a0b6c2782ed6a1c7323d42267183df9bd8b1d57"
+  resolved "https://registry.npmjs.org/domelementtype/-/domelementtype-2.2.0.tgz"
   integrity sha512-DtBMo82pv1dFtUmHyr48beiuq792Sxohr+8Hm9zoxklYPfa6n0Z3Byjj2IV7bmr2IyqClnqEQhfgHJJ5QF0R5A==
 
-domhandler@^4.0.0, domhandler@^4.1.0:
-  version "4.1.0"
-  resolved "https://registry.yarnpkg.com/domhandler/-/domhandler-4.1.0.tgz#c1d8d494d5ec6db22de99e46a149c2a4d23ddd43"
-  integrity sha512-/6/kmsGlMY4Tup/nGVutdrK9yQi4YjWVcVeoQmixpzjOUK1U7pQkvAPHBJeUxOgxF0J8f8lwCJSlCfD0V4CMGQ==
+domhandler@^4.0.0, domhandler@^4.2.0:
+  version "4.2.0"
+  resolved "https://registry.npmjs.org/domhandler/-/domhandler-4.2.0.tgz"
+  integrity sha512-zk7sgt970kzPks2Bf+dwT/PLzghLnsivb9CcxkvR8Mzr66Olr0Ofd8neSbglHJHaHa2MadfoSdNlKYAaafmWfA==
   dependencies:
     domelementtype "^2.2.0"
 
-domutils@^2.4.3:
-  version "2.5.2"
-  resolved "https://registry.yarnpkg.com/domutils/-/domutils-2.5.2.tgz#37ef8ba087dff1a17175e7092e8a042e4b050e6c"
-  integrity sha512-MHTthCb1zj8f1GVfRpeZUbohQf/HdBos0oX5gZcQFepOZPLLRyj6Wn7XS7EMnY7CVpwv8863u2vyE83Hfu28HQ==
+domutils@^2.6.0:
+  version "2.7.0"
+  resolved "https://registry.npmjs.org/domutils/-/domutils-2.7.0.tgz"
+  integrity sha512-8eaHa17IwJUPAiB+SoTYBo5mCdeMgdcAoXJ59m6DT1vw+5iLS3gNoqYaRowaBKtGVrOF1Jz4yDTgYKLK2kvfJg==
   dependencies:
     dom-serializer "^1.0.1"
     domelementtype "^2.2.0"
-    domhandler "^4.1.0"
+    domhandler "^4.2.0"
 
-dropbox@4.0.30:
-  version "4.0.30"
-  resolved "https://registry.yarnpkg.com/dropbox/-/dropbox-4.0.30.tgz#747247b5088e26ab143db39afed8c66f0887d670"
-  integrity sha512-qmSeT8rhjARDHj3vxOTKQjc6IQ46AlRwJS8dqE26R323fikkjC4EXzocV12PsO7DOrjaqbOH3FjEdEEnrFraJw==
+dot-prop@^6.0.1:
+  version "6.0.1"
+  resolved "https://registry.npmjs.org/dot-prop/-/dot-prop-6.0.1.tgz"
+  integrity sha512-tE7ztYzXHIeyvc7N+hR3oi7FIbf/NIjVP9hmAt3yMXzrQ072/fpjGLx2GxNxGxUl5V73MEqYzioOMoVhGMJ5cA==
   dependencies:
-    buffer "^5.0.8"
-    moment "^2.19.3"
+    is-obj "^2.0.0"
 
-duplexer3@^0.1.4:
-  version "0.1.4"
-  resolved "https://registry.yarnpkg.com/duplexer3/-/duplexer3-0.1.4.tgz#ee01dd1cac0ed3cbc7fdbea37dc0a8f1ce002ce2"
-  integrity sha1-7gHdHKwO08vH/b6jfcCo8c4ALOI=
+dropbox@^10.5.0:
+  version "10.5.0"
+  resolved "https://registry.npmjs.org/dropbox/-/dropbox-10.5.0.tgz"
+  integrity sha512-bvyUmkljDrbxJIlIwBvN8g0XYuvSteynJo07G4JXN+qsvfYBnKyL7UrUJ0dn00R0CdvhoVjvC/o+ehu4w1DT3Q==
+  dependencies:
+    node-fetch "^2.6.1"
 
 end-of-stream@^1.1.0:
   version "1.4.4"
-  resolved "https://registry.yarnpkg.com/end-of-stream/-/end-of-stream-1.4.4.tgz#5ae64a5f45057baf3626ec14da0ca5e4b2431eb0"
+  resolved "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.4.tgz"
   integrity sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==
   dependencies:
     once "^1.4.0"
 
 entities@^2.0.0:
   version "2.2.0"
-  resolved "https://registry.yarnpkg.com/entities/-/entities-2.2.0.tgz#098dc90ebb83d8dffa089d55256b351d34c4da55"
+  resolved "https://registry.npmjs.org/entities/-/entities-2.2.0.tgz"
   integrity sha512-p92if5Nz619I0w+akJrLZH0MX0Pb5DX39XOwQTtXSdQQOaYH03S1uIQp4mhOZtAXrxq4ViO67YTiLBo2638o9A==
 
-event-target-shim@^5.0.0:
-  version "5.0.1"
-  resolved "https://registry.yarnpkg.com/event-target-shim/-/event-target-shim-5.0.1.tgz#5d4d3ebdf9583d63a5333ce2deb7480ab2b05789"
-  integrity sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==
+escape-string-regexp@5.0.0:
+  version "5.0.0"
+  resolved "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-5.0.0.tgz"
+  integrity sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw==
 
-get-stream@^5.0.0, get-stream@^5.1.0:
+get-stream@^5.1.0:
   version "5.1.0"
-  resolved "https://registry.yarnpkg.com/get-stream/-/get-stream-5.1.0.tgz#01203cdc92597f9b909067c3e656cc1f4d3c4dc9"
+  resolved "https://registry.npmjs.org/get-stream/-/get-stream-5.1.0.tgz"
   integrity sha512-EXr1FOzrzTfGeL0gQdeFEvOMm2mzMOglyiOXSTpPC+iAjAKftbr3jpCMWynogwYnM+eSj9sHGc6wjIcDvYiygw==
   dependencies:
     pump "^3.0.0"
 
-got@^10.3.0:
-  version "10.3.0"
-  resolved "https://registry.yarnpkg.com/got/-/got-10.3.0.tgz#c67b26b48425d1609dda9004c4013cd379fd15d5"
-  integrity sha512-p7TGnZLgAMTDOwXQnNAF7nTVWmd9YWTvF+64JFKnyskLY0HXUcIyzSz2kfjHIyd8ysA8gr5EXNtOgloiY0Cjrw==
+got@^11.8.2:
+  version "11.8.2"
+  resolved "https://registry.npmjs.org/got/-/got-11.8.2.tgz"
+  integrity sha512-D0QywKgIe30ODs+fm8wMZiAcZjypcCodPNuMz5H9Mny7RJ+IjJ10BdmGW7OM7fHXP+O7r6ZwapQ/YQmMSvB0UQ==
   dependencies:
-    "@sindresorhus/is" "^1.0.0"
-    "@szmarczak/http-timer" "^4.0.0"
+    "@sindresorhus/is" "^4.0.0"
+    "@szmarczak/http-timer" "^4.0.5"
     "@types/cacheable-request" "^6.0.1"
-    cacheable-lookup "^0.2.1"
+    "@types/responselike" "^1.0.0"
+    cacheable-lookup "^5.0.3"
     cacheable-request "^7.0.1"
-    decompress-response "^5.0.0"
-    duplexer3 "^0.1.4"
-    get-stream "^5.0.0"
+    decompress-response "^6.0.0"
+    http2-wrapper "^1.0.0-beta.5.2"
     lowercase-keys "^2.0.0"
-    mimic-response "^2.0.0"
     p-cancelable "^2.0.0"
     responselike "^2.0.0"
-    to-readable-stream "^2.0.0"
-    type-fest "^0.9.0"
 
 he@1.2.0, he@^1.2.0:
   version "1.2.0"
-  resolved "https://registry.yarnpkg.com/he/-/he-1.2.0.tgz#84ae65fa7eafb165fddb61566ae14baf05664f0f"
+  resolved "https://registry.npmjs.org/he/-/he-1.2.0.tgz"
   integrity sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==
 
 http-cache-semantics@^4.0.0:
   version "4.0.3"
-  resolved "https://registry.yarnpkg.com/http-cache-semantics/-/http-cache-semantics-4.0.3.tgz#495704773277eeef6e43f9ab2c2c7d259dda25c5"
+  resolved "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.0.3.tgz"
   integrity sha512-TcIMG3qeVLgDr1TEd2XvHaTnMPwYQUQMIBLy+5pLSDKYFc7UIqj39w8EGzZkaxoLv/l2K8HaI0t5AVA+YYgUew==
 
-ieee754@^1.1.4:
-  version "1.1.13"
-  resolved "https://registry.yarnpkg.com/ieee754/-/ieee754-1.1.13.tgz#ec168558e95aa181fd87d37f55c32bbcb6708b84"
-  integrity sha512-4vf7I2LYV/HaWerSo3XmlMkp5eZ83i+/CDluXi/IGTs/O1sejBNhTtnxzmRZfvOUqj7lZjqHkeTvpgSFDlWZTg==
+http2-wrapper@^1.0.0-beta.5.2:
+  version "1.0.3"
+  resolved "https://registry.npmjs.org/http2-wrapper/-/http2-wrapper-1.0.3.tgz"
+  integrity sha512-V+23sDMr12Wnz7iTcDeJr3O6AIxlnvT/bmaAAAP/Xda35C90p9599p0F1eHR/N1KILWSoWVAiOMFjBBXaXSMxg==
+  dependencies:
+    quick-lru "^5.1.1"
+    resolve-alpn "^1.0.0"
 
-ip-regex@^2.1.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/ip-regex/-/ip-regex-2.1.0.tgz#fa78bf5d2e6913c911ce9f819ee5146bb6d844e9"
-  integrity sha1-+ni/XS5pE8kRzp+BnuUUa7bYROk=
+is-obj@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.npmjs.org/is-obj/-/is-obj-2.0.0.tgz"
+  integrity sha512-drqDG3cbczxxEJRoOXcOjtdp1J/lyp1mNn0xaznRs8+muBhgQcrnbspox5X5fOw0HnMnbfDzvnEMEtqDEJEo8w==
 
 json-buffer@3.0.1:
   version "3.0.1"
-  resolved "https://registry.yarnpkg.com/json-buffer/-/json-buffer-3.0.1.tgz#9338802a30d3b6605fbe0613e094008ca8c05a13"
+  resolved "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz"
   integrity sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==
 
 keyv@^4.0.0:
   version "4.0.0"
-  resolved "https://registry.yarnpkg.com/keyv/-/keyv-4.0.0.tgz#2d1dab694926b2d427e4c74804a10850be44c12f"
+  resolved "https://registry.npmjs.org/keyv/-/keyv-4.0.0.tgz"
   integrity sha512-U7ioE8AimvRVLfw4LffyOIRhL2xVgmE8T22L6i0BucSnBUyv4w+I7VN/zVZwRKHOI6ZRUcdMdWHQ8KSUvGpEog==
   dependencies:
     json-buffer "3.0.1"
 
+lodash.isequal@^4.5.0:
+  version "4.5.0"
+  resolved "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz"
+  integrity sha1-QVxEePK8wwEgwizhDtMib30+GOA=
+
 lowercase-keys@^2.0.0:
   version "2.0.0"
-  resolved "https://registry.yarnpkg.com/lowercase-keys/-/lowercase-keys-2.0.0.tgz#2603e78b7b4b0006cbca2fbcc8a3202558ac9479"
+  resolved "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-2.0.0.tgz"
   integrity sha512-tqNXrS78oMOE73NMxK4EMLQsQowWf8jKooH9g7xPavRT706R6bkQJ6DY2Te7QukaZsulxa30wQ7bk0pm4XiHmA==
 
 mime-db@1.44.0:
   version "1.44.0"
-  resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.44.0.tgz#fa11c5eb0aca1334b4233cb4d52f10c5a6272f92"
+  resolved "https://registry.npmjs.org/mime-db/-/mime-db-1.44.0.tgz"
   integrity sha512-/NOTfLrsPBVeH7YtFPgsVWveuL+4SjjYxaQ1xtM1KMFj7HdxlBlxeyNLzhyJVx7r4rZGJAZ/6lkKCitSc/Nmpg==
 
 mime-types@^2.1.12:
   version "2.1.27"
-  resolved "https://registry.yarnpkg.com/mime-types/-/mime-types-2.1.27.tgz#47949f98e279ea53119f5722e0f34e529bec009f"
+  resolved "https://registry.npmjs.org/mime-types/-/mime-types-2.1.27.tgz"
   integrity sha512-JIhqnCasI9yD+SsmkquHBxTSEuZdQX5BuQnS2Vc7puQQQ+8yiP5AY5uWhpdv4YL4VM5c6iliiYWPgJ/nJQLp7w==
   dependencies:
     mime-db "1.44.0"
 
 mimic-response@^1.0.0:
   version "1.0.1"
-  resolved "https://registry.yarnpkg.com/mimic-response/-/mimic-response-1.0.1.tgz#4923538878eef42063cb8a3e3b0798781487ab1b"
+  resolved "https://registry.npmjs.org/mimic-response/-/mimic-response-1.0.1.tgz"
   integrity sha512-j5EctnkH7amfV/q5Hgmoal1g2QHFJRraOtmx0JpIqkxhBhI/lJSl1nMpQ45hVarwNETOoWEimndZ4QK0RHxuxQ==
 
-mimic-response@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/mimic-response/-/mimic-response-2.0.0.tgz#996a51c60adf12cb8a87d7fb8ef24c2f3d5ebb46"
-  integrity sha512-8ilDoEapqA4uQ3TwS0jakGONKXVJqpy+RpM+3b7pLdOjghCrEiGp9SRkFbUHAmZW9vdnrENWHjaweIoTIJExSQ==
+mimic-response@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.npmjs.org/mimic-response/-/mimic-response-3.1.0.tgz"
+  integrity sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==
 
 minimatch@3.0.4:
   version "3.0.4"
-  resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-3.0.4.tgz#5166e286457f03306064be5497e8dbb0c3d32083"
+  resolved "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz"
   integrity sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==
   dependencies:
     brace-expansion "^1.1.7"
 
-moment@^2.19.3:
-  version "2.24.0"
-  resolved "https://registry.yarnpkg.com/moment/-/moment-2.24.0.tgz#0d055d53f5052aa653c9f6eb68bb5d12bf5c2b5b"
-  integrity sha512-bV7f+6l2QigeBBZSM/6yTNq4P2fNpSWj/0e7jQcy87A8e7o2nAfP/34/2ky5Vw4B9S446EtIhodAzkFCcR4dQg==
-
-node-fetch@^2.6.0, node-fetch@^2.6.1:
+node-fetch@^2.6.1:
   version "2.6.1"
-  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.6.1.tgz#045bd323631f76ed2e2b55573394416b639a0052"
+  resolved "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.1.tgz"
   integrity sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw==
 
-node-html-parser@^3.1.3:
-  version "3.1.3"
-  resolved "https://registry.yarnpkg.com/node-html-parser/-/node-html-parser-3.1.3.tgz#987d39bc8df27bc70cbe3b4e9a31fd84f7454dfb"
-  integrity sha512-pCE2I5UY5iOBnWdJQkbYZSk+fyq2zepw0nsELpHQjVFyCzOeZhkMhnvKqGceKgzWsWx7EG4KtMqsy9Eklf5Thw==
+node-html-parser@^4.1.3:
+  version "4.1.3"
+  resolved "https://registry.npmjs.org/node-html-parser/-/node-html-parser-4.1.3.tgz"
+  integrity sha512-jWFd9TBxDJ0hXkvPKxiWXy4R87ZoIjYj5P2twbef3q/E4vJyFt8TTRQ68ssHYW5Aozwth4SWHOPT6yfDd/gzQQ==
   dependencies:
-    css-select "^3.1.2"
+    css-select "^4.1.3"
     he "1.2.0"
 
 normalize-url@^4.1.0:
-  version "4.5.0"
-  resolved "https://registry.yarnpkg.com/normalize-url/-/normalize-url-4.5.0.tgz#453354087e6ca96957bd8f5baf753f5982142129"
-  integrity sha512-2s47yzUxdexf1OhyRi4Em83iQk0aPvwTddtFz4hnSSw9dCEsLEGf6SwIO8ss/19S9iBb5sJaOuTvTGDeZI00BQ==
+  version "4.5.1"
+  resolved "https://registry.npmjs.org/normalize-url/-/normalize-url-4.5.1.tgz"
+  integrity sha512-9UZCFRHQdNrfTpGg8+1INIg93B6zE0aXMVFkw1WFwvO4SlZywU6aLg5Of0Ap/PgcbSw4LNxvMWXMeugwMCX0AA==
 
 nth-check@^2.0.0:
   version "2.0.0"
-  resolved "https://registry.yarnpkg.com/nth-check/-/nth-check-2.0.0.tgz#1bb4f6dac70072fc313e8c9cd1417b5074c0a125"
+  resolved "https://registry.npmjs.org/nth-check/-/nth-check-2.0.0.tgz"
   integrity sha512-i4sc/Kj8htBrAiH1viZ0TgU8Y5XqCaV/FziYK6TBczxmeKm3AEFWqqF3195yKudrarqy7Zu80Ra5dobFjn9X/Q==
   dependencies:
     boolbase "^1.0.0"
 
 once@^1.3.1, once@^1.4.0:
   version "1.4.0"
-  resolved "https://registry.yarnpkg.com/once/-/once-1.4.0.tgz#583b1aa775961d4b113ac17d9c50baef9dd76bd1"
+  resolved "https://registry.npmjs.org/once/-/once-1.4.0.tgz"
   integrity sha1-WDsap3WWHUsROsF9nFC6753Xa9E=
   dependencies:
     wrappy "1"
 
+ow@^0.27.0:
+  version "0.27.0"
+  resolved "https://registry.npmjs.org/ow/-/ow-0.27.0.tgz"
+  integrity sha512-SGnrGUbhn4VaUGdU0EJLMwZWSupPmF46hnTRII7aCLCrqixTAC5eKo8kI4/XXf1eaaI8YEVT+3FeGNJI9himAQ==
+  dependencies:
+    "@sindresorhus/is" "^4.0.1"
+    callsites "^3.1.0"
+    dot-prop "^6.0.1"
+    lodash.isequal "^4.5.0"
+    type-fest "^1.2.1"
+    vali-date "^1.0.0"
+
 p-cancelable@^2.0.0:
   version "2.0.0"
-  resolved "https://registry.yarnpkg.com/p-cancelable/-/p-cancelable-2.0.0.tgz#4a3740f5bdaf5ed5d7c3e34882c6fb5d6b266a6e"
+  resolved "https://registry.npmjs.org/p-cancelable/-/p-cancelable-2.0.0.tgz"
   integrity sha512-wvPXDmbMmu2ksjkB4Z3nZWTSkJEb9lqVdMaCKpZUGJG9TMiNp9XcbG3fn9fPKjem04fJMJnXoyFPk2FmgiaiNg==
 
-prism-media@^1.2.2:
-  version "1.2.2"
-  resolved "https://registry.yarnpkg.com/prism-media/-/prism-media-1.2.2.tgz#4f1c841f248b67d325a24b4e6b1a491b8f50a24f"
-  integrity sha512-I+nkWY212lJ500jLe4tN9tWO7nRiBAVdMv76P9kffZjYhw20raMlW1HSSvS+MLXC9MmbNZCazMrAr+5jEEgTuw==
-
-psl@^1.1.28:
-  version "1.4.0"
-  resolved "https://registry.yarnpkg.com/psl/-/psl-1.4.0.tgz#5dd26156cdb69fa1fdb8ab1991667d3f80ced7c2"
-  integrity sha512-HZzqCGPecFLyoRj5HLfuDSKYTJkAfB5thKBIkRHtGjWwY7p1dAyveIbXIq4tO0KYfDF2tHqPUgY9SDnGm00uFw==
+psl@^1.1.33:
+  version "1.8.0"
+  resolved "https://registry.npmjs.org/psl/-/psl-1.8.0.tgz"
+  integrity sha512-RIdOzyoavK+hA18OGGWDqUTsCLhtA7IcZ/6NCs4fFJaHBDab+pDDmDIByWFRQJq2Cd7r1OoQxBGKOaztq+hjIQ==
 
 pump@^3.0.0:
   version "3.0.0"
-  resolved "https://registry.yarnpkg.com/pump/-/pump-3.0.0.tgz#b4a2116815bde2f4e1ea602354e8c75565107a64"
+  resolved "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz"
   integrity sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==
   dependencies:
     end-of-stream "^1.1.0"
@@ -421,58 +442,73 @@ pump@^3.0.0:
 
 punycode@^2.1.1:
   version "2.1.1"
-  resolved "https://registry.yarnpkg.com/punycode/-/punycode-2.1.1.tgz#b58b010ac40c22c5657616c8d2c2c02c7bf479ec"
+  resolved "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz"
   integrity sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==
+
+quick-lru@^5.1.1:
+  version "5.1.1"
+  resolved "https://registry.npmjs.org/quick-lru/-/quick-lru-5.1.1.tgz"
+  integrity sha512-WuyALRjWPDGtt/wzJiadO5AXY+8hZ80hVpe6MyivgraREW751X3SbhRvG3eLKOYN+8VEvqLcf3wdnt44Z4S4SA==
 
 recursive-readdir@^2.2.2:
   version "2.2.2"
-  resolved "https://registry.yarnpkg.com/recursive-readdir/-/recursive-readdir-2.2.2.tgz#9946fb3274e1628de6e36b2f6714953b4845094f"
+  resolved "https://registry.npmjs.org/recursive-readdir/-/recursive-readdir-2.2.2.tgz"
   integrity sha512-nRCcW9Sj7NuZwa2XvH9co8NPeXUBhZP7CRKJtU+cS6PW9FpCIFoI5ib0NT1ZrbNuPoRy0ylyCaUL8Gih4LSyFg==
   dependencies:
     minimatch "3.0.4"
 
+resolve-alpn@^1.0.0:
+  version "1.2.0"
+  resolved "https://registry.npmjs.org/resolve-alpn/-/resolve-alpn-1.2.0.tgz"
+  integrity sha512-e4FNQs+9cINYMO5NMFc6kOUCdohjqFPSgMuwuZAOUWqrfWsen+Yjy5qZFkV5K7VO7tFSLKcUL97olkED7sCBHA==
+
 responselike@^2.0.0:
   version "2.0.0"
-  resolved "https://registry.yarnpkg.com/responselike/-/responselike-2.0.0.tgz#26391bcc3174f750f9a79eacc40a12a5c42d7723"
+  resolved "https://registry.npmjs.org/responselike/-/responselike-2.0.0.tgz"
   integrity sha512-xH48u3FTB9VsZw7R+vvgaKeLKzT6jOogbQhEe/jewwnZgzPcnyWui2Av6JpoYZF/91uueC+lqhWqeURw5/qhCw==
   dependencies:
     lowercase-keys "^2.0.0"
 
-setimmediate@^1.0.5:
-  version "1.0.5"
-  resolved "https://registry.yarnpkg.com/setimmediate/-/setimmediate-1.0.5.tgz#290cbb232e306942d7d7ea9b83732ab7856f8285"
-  integrity sha1-KQy7Iy4waULX1+qbg3Mqt4VvgoU=
-
-to-readable-stream@^2.0.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/to-readable-stream/-/to-readable-stream-2.1.0.tgz#82880316121bea662cdc226adb30addb50cb06e8"
-  integrity sha512-o3Qa6DGg1CEXshSdvWNX2sN4QHqg03SPq7U6jPXRahlQdl5dK8oXjkU/2/sGrnOZKeGV1zLSO8qPwyKklPPE7w==
-
-tough-cookie@3.0.1:
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/tough-cookie/-/tough-cookie-3.0.1.tgz#9df4f57e739c26930a018184887f4adb7dca73b2"
-  integrity sha512-yQyJ0u4pZsv9D4clxO69OEjLWYw+jbgspjTue4lTQZLfV0c5l1VmK2y1JK8E9ahdpltPOaAThPcp5nKPUgSnsg==
+tough-cookie@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.npmjs.org/tough-cookie/-/tough-cookie-4.0.0.tgz"
+  integrity sha512-tHdtEpQCMrc1YLrMaqXXcj6AxhYi/xgit6mZu1+EDWUn+qhUf8wMQoFIy9NXuq23zAwtcB0t/MjACGR18pcRbg==
   dependencies:
-    ip-regex "^2.1.0"
-    psl "^1.1.28"
+    psl "^1.1.33"
     punycode "^2.1.1"
+    universalify "^0.1.2"
 
-tweetnacl@^1.0.3:
-  version "1.0.3"
-  resolved "https://registry.yarnpkg.com/tweetnacl/-/tweetnacl-1.0.3.tgz#ac0af71680458d8a6378d0d0d050ab1407d35596"
-  integrity sha512-6rt+RN7aOi1nGMyC4Xa5DdYiukl2UWCbcJft7YhxReBGQD7OAM8Pbxw6YMo4r2diNEA8FEmu32YOn9rhaiE5yw==
+ts-mixer@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.npmjs.org/ts-mixer/-/ts-mixer-6.0.0.tgz"
+  integrity sha512-nXIb1fvdY5CBSrDIblLn73NW0qRDk5yJ0Sk1qPBF560OdJfQp9jhl+0tzcY09OZ9U+6GpeoI9RjwoIKFIoB9MQ==
 
-type-fest@^0.9.0:
-  version "0.9.0"
-  resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-0.9.0.tgz#3b7904821e42b26377831a6e9b5d2930ab19c99a"
-  integrity sha512-j55pzONIdg7rdtJTRZPKIbV0FosUqYdhHK1aAYJIrUvejv1VVyBokrILE8KQDT4emW/1Ev9tx+yZG+AxuSBMmA==
+tslib@^2.3.0:
+  version "2.3.0"
+  resolved "https://registry.npmjs.org/tslib/-/tslib-2.3.0.tgz"
+  integrity sha512-N82ooyxVNm6h1riLCoyS9e3fuJ3AMG2zIZs2Gd1ATcSFjSA23Q0fzjjZeh0jbJvWVDZ0cJT8yaNNaaXHzueNjg==
+
+type-fest@^1.2.1:
+  version "1.4.0"
+  resolved "https://registry.npmjs.org/type-fest/-/type-fest-1.4.0.tgz"
+  integrity sha512-yGSza74xk0UG8k+pLh5oeoYirvIiWo5t0/o3zHHAO2tRDiZcxWP7fywNlXhqb6/r6sWvwi+RsyQMWhVLe4BVuA==
+
+universalify@^0.1.2:
+  version "0.1.2"
+  resolved "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz"
+  integrity sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==
+
+vali-date@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.npmjs.org/vali-date/-/vali-date-1.0.0.tgz"
+  integrity sha1-G5BKWWCfsyjvB4E4Qgk09rhnCaY=
 
 wrappy@1:
   version "1.0.2"
-  resolved "https://registry.yarnpkg.com/wrappy/-/wrappy-1.0.2.tgz#b5243d8f3ec1aa35f1364605bc0d1036e30ab69f"
+  resolved "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz"
   integrity sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=
 
-ws@^7.3.1:
-  version "7.3.1"
-  resolved "https://registry.yarnpkg.com/ws/-/ws-7.3.1.tgz#d0547bf67f7ce4f12a72dfe31262c68d7dc551c8"
-  integrity sha512-D3RuNkynyHmEJIpD2qrgVkc9DQ23OrN/moAwZX4L8DfvszsJxpjQuUq3LMx6HoYji9fbIOBY18XWBsAux1ZZUA==
+ws@^7.5.1:
+  version "7.5.3"
+  resolved "https://registry.npmjs.org/ws/-/ws-7.5.3.tgz"
+  integrity sha512-kQ/dHIzuLrS6Je9+uv81ueZomEwH0qVYstcAQ4/Z93K8zeko9gtAbttJWzoC5ukqXY1PpoouV3+VSOqEAFt5wg==


### PR DESCRIPTION
- discord.js v13 is here! And so are breaking changes that should hopefully be fixed in this pull request.
- Since discord.js added a Node.js v16+ requirement, and Node.js v15 FINALLY started actually crashing the process on unhandled promises, error handling has been improved:
    - I made sure methods which return promises aren't left un`await`ed (or un`.catch`'d)
    - The `unhandledRejection` event should now be handled by reporting the error (I think handling this event makes Node not crash our process?).
    - There is now a `Twinkle#reportError` method for centralized error reporting, and a new configuration option `TWINKLE.REPORTING.CHANNEL` which specifies the channel Twinkle can use for error reporting. I made sure most things that used `console` before now actually use this.
    - There is also a `Twinkle#wrapListener` for wrapping our event listeners in an error handler which calls `Twinkle#reportError`.
- Unrelated to all that, SIGINT is now handled properly by calling the `cleanup` method for Twinkle, which calls `cleanup` methods for individual plugins, and commander calls `cleanup` methods for commands, etc. Hopefully, all should be cleaned up before attempting a shutdown.