### PR TITLE
Use single backtick

### DIFF
--- a/src/plugins/fmt/index.js
+++ b/src/plugins/fmt/index.js
@@ -74,7 +74,7 @@ class Formatter {
     }
 
     code(content) {
-        return this.sugar(content, [ this.ZWSP ], '``')
+        return this.sugar(content, [ this.ZWSP ], '`')
     }
 
     italic(content) {


### PR DESCRIPTION
Apparently, two backticks are broken on Droidcord.