### PR TITLE
Add cross wiki search prefix

### DIFF
--- a/src/plugins/linker/index.js
+++ b/src/plugins/linker/index.js
@@ -65,6 +65,8 @@ class Linker {
         this.addLinkTarget(['wp'], ['wikipedia'], ({ full }) => `https://en.wikipedia.org/wiki/${this.encode(full)}`);
         this.addLinkTarget(['g'], ['google'], ({ full }) => `https://www.google.com/search?q=${this.encode(full, { '20': '+' })}`);
         this.addLinkTarget(['lmgtfy'], ({ full }) => `https://lmgtfy.com/?q=${this.encode(full, { '20': '+' })}`);
+        
+        this.addLinkTarget('cws', ({ full }) => `https://dev.fandom.com/wiki/Special:Search?query=${this.encode(full, { '20': '+' })}&scope=cross-wiki`);
 
         this.addLinkTarget('w', 'c', async ({ parts: [wiki, ...rest] }) => `${await this.wikiUrl(wiki)}/wiki/${this.encode(rest.join(':'))}`);
         this.addLinkTarget('w', ({ full }) => `https://community.fandom.com/wiki/${this.encode(full)}`);


### PR DESCRIPTION
Figured this might be useful for seeing if stuff is being used across fandom, not really tried to the search prefix name if you want to change that, or I can change it to a command instead if y'all think that would be better.