### PR TITLE
change up paste links

### DIFF
--- a/src/plugins/commander/commands/code.js
+++ b/src/plugins/commander/commands/code.js
@@ -31,7 +31,8 @@ You can use:
 \\\`\\\`\\\`
  - a link to your Fandom/GitHub file
  - a code snippet site:
-<https://dpaste.org/> • <https://privatebin.net/> • <https://pst.klgrth.io/> • <https://hastebin.com/>
+<https://dpaste.org/> • <https://privatebin.net/> • <https://pst.klgrth.io/> • <https://hastebin.com/> • <https://gist.github.com/>
+ - save your code as a file and upload it here
 Please *don't* use screenshots, we can't read those!`);
     }
 }

--- a/src/plugins/commander/commands/code.js
+++ b/src/plugins/commander/commands/code.js
@@ -31,7 +31,7 @@ You can use:
 \\\`\\\`\\\`
  - a link to your Fandom/GitHub file
  - a code snippet site:
-<https://gist.github.com/> • <https://hastebin.com/> • <https://privatebin.net/> • <https://ghostbin.com/> • <https://pastebin.com/>
+<https://dpaste.org/> • <https://privatebin.net/> • <https://pst.klgrth.io/> • <https://hastebin.com/>
 Please *don't* use screenshots, we can't read those!`);
     }
 }


### PR DESCRIPTION
-github gist requires auth so moved to the end
-remove pastebin.com due to having ads/popups/etc (I'm fine with keeping it if y'all want)
-move hastebin back a bit as I've got some nitpicks with it
-change ghostbin to the url it redirects to (looks like it shut down, not sure if the domain is controlled by the same person now)
-add dpaste