### PR TITLE
Allow multiple IPC sockets

### DIFF
--- a/src/plugins/ipc/index.js
+++ b/src/plugins/ipc/index.js
@@ -1,5 +1,5 @@
 const { createServer } = require('net');
-const fs = require('fs');
+const { unlink } = require('fs/promises');
 const Plugin = require('../../structs/Plugin.js');
 
 class IPCPlugin extends Plugin {
@@ -37,7 +37,7 @@ class IPC {
     async unlinkSocket() {
         if (typeof this.config.SOCKET_PATH === 'string') {
             try {
-                await fs.promises.unlink(this.config.SOCKET_PATH);
+                await unlink(this.config.SOCKET_PATH);
             } catch {}
         }
     }

--- a/src/plugins/ipc/index.js
+++ b/src/plugins/ipc/index.js
@@ -5,21 +5,26 @@ const Plugin = require('../../structs/Plugin.js');
 class IPCPlugin extends Plugin {
     load() {
         if (this.bot.config.IPC) {
-            this.bot.ipc = new IPC(this.bot);
+            const ipcConfig = this.bot.config.IPC;
+            if (Array.isArray(ipcConfig)) {
+                this.bot.ipc = ipcConfig.map(c => new IPC(this.bot, c));
+            } else {
+                this.bot.ipc = [new IPC(this.bot, ipcConfig)];
+            }
         }
     }
 
-    cleanup() {
+    async cleanup() {
         if (this.bot.ipc) {
-            this.bot.ipc.cleanup();
+            await Promise.all(this.bot.ipc.map(i => i.cleanup()));
         }
     }
 }
 
 class IPC {
-    constructor(bot) {
+    constructor(bot, config) {
         Object.defineProperty(this, 'bot', { value: bot });
-        Object.defineProperty(this, 'config', { value: bot.config.IPC });
+        Object.defineProperty(this, 'config', { value: config });
 
         this.connections = {};
         this.connectionCount = 0;


### PR DESCRIPTION
This is useful when we want separate sockets for sending messages to different channels.